### PR TITLE
Change nuget path to match the userprofile path for easier installation

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
@@ -17,7 +17,7 @@
   <files>
     <file src="ThirdPartyNotices.txt" target="\" />
     <file src="EULA_Microsoft Visual Studio Team Services Credential Provider.docx" target="\" />
-    <file src="bin\$Configuration$\net461\**\*.*" target="\tools\net461" />
-    <file src="bin\$Configuration$\netcoreapp2.1\publish\**\*.*" target="\tools\netcoreapp2.1" />
+    <file src="bin\$Configuration$\net461\**\*.*" target="\.nuget\plugins\netfx\CredentialProvider.Microsoft" />
+    <file src="bin\$Configuration$\netcoreapp2.1\publish\**\*.*" target="\.nuget\plugins\netcore\CredentialProvider.Microsoft" />
   </files>
 </package>


### PR DESCRIPTION
Updating the paths in the nuget package to match where nuget will expect them to be as defined by the [spec](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery).