### PR TITLE
clearing signtype in build.yml before packing

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -76,6 +76,9 @@ steps:
       command: test
       projects: 'CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj'
 
+- powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")' 
+  displayName: Clear SignType
+
 - task: DotNetCoreCLI@2
   displayName: dotnet pack
   inputs:


### PR DESCRIPTION
Since dotnet pack targets the csproj instead of the nuspec, the MicroBuild signing binaries were being imported and they attempted to sign the package output. Clearing SignType before packing fixes this.