### PR TITLE
Missing curlybraces in a crucial documentation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The Credential Provider accepts a set of environment variables. These are the on
 -   `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`: Json that contains an array of service endpoints, usernames and access tokens to authenticate endpoints in nuget.config. Example:
 
 ```
- {"endpointCredentials": ["endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"]}"
+ {"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}"
 ```
 
 ## Help

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The Credential Provider accepts a set of environment variables. These are the on
 -   `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS`: Json that contains an array of service endpoints, usernames and access tokens to authenticate endpoints in nuget.config. Example:
 
 ```
- {"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}"
+ {"endpointCredentials": [{"endpoint":"http://example.index.json", "username":"optional", "password":"accesstoken"}]}
 ```
 
 ## Help


### PR DESCRIPTION
Caused me a bit of confusion, as I was trying to operate with environment variables based on the example and didn't see the error at first!