### PR TITLE
Add more verbose logging and move stuff around

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>0.1.9</CredentialProviderVersion>
+    <CredentialProviderVersion>0.1.10</CredentialProviderVersion>
   </PropertyGroup>
 </Project>

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -66,6 +66,19 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
         }
 
         [TestMethod]
+        public async Task HandleRequestAsync_ReturnsSuccess()
+        {
+            Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
+            string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
+            string feedEndPointJson = "{\"endpointCredentials\":[{\"endpoint\":\"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser\", \"password\":\"testToken\"}]}";
+
+            Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, feedEndPointJson);
+
+            var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Assert.AreEqual(result.ResponseCode, MessageResponseCode.Success);
+        }
+
+        [TestMethod]
         public async Task HandleRequestAsync_ReturnsErrorWhenMatchingEndpointIsNotFound()
         {
             Uri sourceUri = new Uri(@"http://exampleThatDoesNotMatch.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -76,6 +76,29 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
 
             var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
             Assert.AreEqual(result.ResponseCode, MessageResponseCode.Success);
+            Assert.AreEqual(result.Username, "testUser");
+            Assert.AreEqual(result.Password, "testToken");
+        }
+
+        [TestMethod]
+        public async Task HandleRequestAsync_ReturnsSuccessWhenMultipleSourcesInJson()
+        {
+            Uri sourceUri = new Uri(@"http://example3.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
+            string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
+
+            string feedEndPointJson = "{\"endpointCredentials\":[" +
+                "{\"endpoint\":\"http://example1.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser1\", \"password\":\"testToken1\"}, " +
+                "{\"endpoint\":\"http://example2.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser2\", \"password\":\"testToken2\"}, " +
+                "{\"endpoint\":\"http://example3.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser3\", \"password\":\"testToken3\"}, " +
+                "{\"endpoint\":\"http://example4.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser4\", \"password\":\"testToken4\"}" +
+                "]}";
+
+            Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, feedEndPointJson);
+
+            var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Assert.AreEqual(result.ResponseCode, MessageResponseCode.Success);
+            Assert.AreEqual(result.Username, "testUser3");
+            Assert.AreEqual(result.Password, "testToken3");
         }
 
         [TestMethod]

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -3,10 +3,12 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
+using NuGet.Protocol.Plugins;
 using NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoint;
 using NuGetCredentialProvider.Logging;
 using NuGetCredentialProvider.Util;
@@ -51,7 +53,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
         }
 
         [TestMethod]
-        public async Task CanProvideCredentials_ReturnsTrueForCorrectEnvironmentVariableAndMatchingSourceUri()
+        public async Task CanProvideCredentials_ReturnsTrueForCorrectEnvironmentVariable()
         {
             Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
             string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
@@ -64,20 +66,20 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
         }
 
         [TestMethod]
-        public async Task CanProvideCredentials_ReturnsFalseWhenMatchingEndpointIsNotFound()
+        public async Task HandleRequestAsync_ReturnsErrorWhenMatchingEndpointIsNotFound()
         {
             Uri sourceUri = new Uri(@"http://exampleThatDoesNotMatch.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
             string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
             string feedEndPointJson = "{\"endpointCredentials\":[{\"endpoint\":\"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser\", \"password\":\"testToken\"}]}";
 
             Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, feedEndPointJson);
-
-            var result = await vstsCredentialProvider.CanProvideCredentialsAsync(sourceUri);
-            Assert.AreEqual(false, result);
+            
+            var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Assert.AreEqual(result.ResponseCode, MessageResponseCode.Error);
         }
 
         [TestMethod]
-        public async Task CanProvideCredentials_ThrowsWithInvalidJson()
+        public async Task HandleRequestAsync_ThrowsWithInvalidJson()
         {
             Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
             string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
@@ -85,7 +87,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
 
             Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, invalidFeedEndPointJson);
 
-            Action act = () => vstsCredentialProvider.CanProvideCredentialsAsync(sourceUri);
+            Action act = () => vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
             act.Should().Throw<Exception>();
         }
     }

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -37,20 +37,6 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public override async Task<bool> CanProvideCredentialsAsync(Uri uri)
         {
-            string buildTaskJsonEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskExternalEndpoints);
-            string buildTaskPrefixesEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskUriPrefixes);
-            string buildTaskAccessTokenEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
-
-            bool shouldUseBuildTaskCredProvider = string.IsNullOrWhiteSpace(buildTaskJsonEnvVar) == false 
-                || string.IsNullOrWhiteSpace(buildTaskPrefixesEnvVar) == false 
-                || string.IsNullOrWhiteSpace(buildTaskAccessTokenEnvVar) == false;
-            if (shouldUseBuildTaskCredProvider)
-            {
-                // If env vars for build task cred providers are set, this cred provider cannot be used.
-                Verbose(Resources.BuildTaskCredProviderIsUsedError);
-                return await Task.FromResult(false);
-            }
-
             var validHosts = EnvUtil.GetHostsFromEnvironment(Logger, EnvUtil.SupportedHostsEnvVar, new[]
             {
                 ".pkgs.vsts.me", // DevFabric

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -37,6 +37,20 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public override async Task<bool> CanProvideCredentialsAsync(Uri uri)
         {
+            string buildTaskJsonEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskExternalEndpoints);
+            string buildTaskPrefixesEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskUriPrefixes);
+            string buildTaskAccessTokenEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
+
+            bool shouldUseBuildTaskCredProvider = string.IsNullOrWhiteSpace(buildTaskJsonEnvVar) == false 
+                || string.IsNullOrWhiteSpace(buildTaskPrefixesEnvVar) == false 
+                || string.IsNullOrWhiteSpace(buildTaskAccessTokenEnvVar) == false;
+            if (shouldUseBuildTaskCredProvider)
+            {
+                // If env vars for build task cred providers are set, this cred provider cannot be used.
+                Verbose(Resources.BuildTaskCredProviderIsUsedError);
+                return await Task.FromResult(false);
+            }
+
             var validHosts = EnvUtil.GetHostsFromEnvironment(Logger, EnvUtil.SupportedHostsEnvVar, new[]
             {
                 ".pkgs.vsts.me", // DevFabric

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
@@ -61,8 +61,9 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTask
 
         public override Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request, CancellationToken cancellationToken)
         {
-            string accessToken = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
+            cancellationToken.ThrowIfCancellationRequested();
 
+            string accessToken = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
             return this.GetResponse(
                     Username,
                     accessToken,

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
@@ -62,16 +62,6 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTask
         public override Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request, CancellationToken cancellationToken)
         {
             string accessToken = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
-            bool isRetry = request.IsRetry;
-
-            if (isRetry)
-            {
-                return this.GetResponse(
-                    Username,
-                    null,
-                    string.Format(Resources.BuildTaskIsRetry, request.Uri.ToString()),
-                    MessageResponseCode.Error);
-            }
 
             return this.GetResponse(
                     Username,

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -60,12 +60,13 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
             }
 
             string uriString = uri.ToString();
-            if (Credentials.ContainsKey(uriString))
+            if (!Credentials.ContainsKey(uriString))
             {
-                return Task.FromResult(true);
+                Verbose(string.Format(Resources.BuildTaskEndpointNoMatchingUrl, uriString));
+                return Task.FromResult(false);
             }
 
-            return Task.FromResult(false);
+            return Task.FromResult(true);
         }
 
         public override Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request, CancellationToken cancellationToken)

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -57,8 +57,8 @@ namespace NuGetCredentialProvider
         {
             CancellationTokenSource tokenSource = new CancellationTokenSource();
             var parsedArgs = await Args.ParseAsync<CredentialProviderArgs>(args);
-            var multiLogger = new MultiLogger();
 
+            var multiLogger = new MultiLogger();
             var fileLogger = GetFileLogger();
             if (fileLogger != null)
             {
@@ -69,6 +69,7 @@ namespace NuGetCredentialProvider
             Console.CancelKeyPress += (object sender, ConsoleCancelEventArgs eventArgs) =>
             {
                 // ConsoleCancelEventArgs.Cancel defaults to false which terminates the current process.
+                multiLogger.Verbose(Resources.CancelMessage);
                 tokenSource.Cancel();
             };
 
@@ -95,8 +96,6 @@ namespace NuGetCredentialProvider
                     { MessageMethod.SetLogLevel, new SetLogLevelRequestHandler(multiLogger) },
                     { MessageMethod.SetCredentials, new SetCredentialsRequestHandler(multiLogger) },
                 };
-
-                multiLogger.Verbose(string.Format(Resources.CommandLineArgs, Program.Version, Environment.CommandLine));
 
                 // Help
                 if (parsedArgs.Help)
@@ -128,11 +127,12 @@ namespace NuGetCredentialProvider
                 // Plug-in mode
                 if (parsedArgs.Plugin)
                 {
-                    multiLogger.Verbose(Resources.RunningInPlugin);
-
                     using (IPlugin plugin = await PluginFactory.CreateFromCurrentProcessAsync(requestHandlers, ConnectionOptions.CreateDefault(), tokenSource.Token).ConfigureAwait(continueOnCapturedContext: false))
                     {
                         multiLogger.Add(new PluginConnectionLogger(plugin.Connection));
+                        multiLogger.Verbose(Resources.RunningInPlugin);
+                        multiLogger.Verbose(string.Format(Resources.CommandLineArgs, Program.Version, Environment.CommandLine));
+
                         await RunNuGetPluginsAsync(plugin, multiLogger, TimeSpan.FromMinutes(2), tokenSource.Token).ConfigureAwait(continueOnCapturedContext: false);
                     }
 
@@ -145,6 +145,7 @@ namespace NuGetCredentialProvider
                     multiLogger.Add(new ConsoleLogger());
                     multiLogger.SetLogLevel(parsedArgs.Verbosity);
                     multiLogger.Verbose(Resources.RunningInStandAlone);
+                    multiLogger.Verbose(string.Format(Resources.CommandLineArgs, Program.Version, Environment.CommandLine));
 
                     if (parsedArgs.Uri == null)
                     {

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -53,6 +53,9 @@ namespace NuGetCredentialProvider
             return typeof(Program).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "";
         });
 
+        private static bool shuttingDown = false;
+        public static bool IsShuttingDown => Volatile.Read(ref shuttingDown);
+
         public static async Task<int> Main(string[] args)
         {
             CancellationTokenSource tokenSource = new CancellationTokenSource();
@@ -181,6 +184,8 @@ namespace NuGetCredentialProvider
                 logger.Error(string.Format(Resources.FaultedOnMessage, $"{a.Message?.Type} {a.Message?.Method} {a.Message?.RequestId}"));
                 logger.Error(a.Exception.ToString());
             };
+
+            plugin.BeforeClose += (sender, args) => Volatile.Write(ref shuttingDown, true);
 
             plugin.Closed += (sender, a) => semaphore.Release();
 

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Threading;
 using System.Threading.Tasks;
 using NuGet.Protocol.Plugins;

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -60,22 +60,22 @@ namespace NuGetCredentialProvider.RequestHandlers
 
             Logger.Verbose(string.Format(Resources.Uri, request.Uri));
 
-            if (TryCache(request, out string cachedToken))
-            {
-                return new GetAuthenticationCredentialsResponse(
-                    username: "VssSessionToken",
-                    password: cachedToken,
-                    message: null,
-                    authenticationTypes: new List<string> { "Basic" },
-                    responseCode: MessageResponseCode.Success);
-            }
-
             foreach (ICredentialProvider credentialProvider in credentialProviders)
             {
                 if (await credentialProvider.CanProvideCredentialsAsync(request.Uri) == false)
                 {
                     Logger.Verbose(string.Format(Resources.SkippingCredentialProvider, credentialProvider, request.Uri.ToString()));
                     continue;
+                }
+
+                if (credentialProvider.IsCachable && TryCache(request, out string cachedToken))
+                {
+                    return new GetAuthenticationCredentialsResponse(
+                        username: "VssSessionToken",
+                        password: cachedToken,
+                        message: null,
+                        authenticationTypes: new List<string> { "Basic" },
+                        responseCode: MessageResponseCode.Success);
                 }
 
                 try

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -97,7 +97,14 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to To sign in, use a web browser to open the page {0} and enter the code {1} to authenticate..
+        ///   Looks up a localized string similar to ATTENTION: User interaction required. 
+        ///
+        ///    **********************************************************************
+        ///
+        ///    To sign in, use a web browser to open the page {0} and enter the code {1} to authenticate.
+        ///
+        ///    **********************************************************************
+        ///.
         /// </summary>
         internal static string AdalDeviceFlowMessage {
             get {
@@ -187,7 +194,16 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to URL {0} did not have credentials stored in the environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS..
+        ///   Looks up a localized string similar to Found credentials for endpoint {0}.
+        /// </summary>
+        internal static string BuildTaskEndpointMatchingUrlFound {
+            get {
+                return ResourceManager.GetString("BuildTaskEndpointMatchingUrlFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS did not have credentials for endpoint {0}.
         /// </summary>
         internal static string BuildTaskEndpointNoMatchingUrl {
             get {
@@ -207,9 +223,9 @@ namespace NuGetCredentialProvider {
         /// <summary>
         ///   Looks up a localized string similar to Failed to authenticate to {0} from your project collection.
         /// </summary>
-        internal static string BuildTaskIsRetry {
+        internal static string BuildTaskFailedToAuthenticate {
             get {
-                return ResourceManager.GetString("BuildTaskIsRetry", resourceCulture);
+                return ResourceManager.GetString("BuildTaskFailedToAuthenticate", resourceCulture);
             }
         }
         
@@ -255,6 +271,15 @@ namespace NuGetCredentialProvider {
         internal static string CachingSessionToken {
             get {
                 return ResourceManager.GetString("CachingSessionToken", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Canceling credential provider.
+        /// </summary>
+        internal static string CancelMessage {
+            get {
+                return ResourceManager.GetString("CancelMessage", resourceCulture);
             }
         }
         

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -169,11 +169,29 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to This credential provider must not run if build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS.
+        /// </summary>
+        internal static string BuildTaskCredProviderIsUsedError {
+            get {
+                return ResourceManager.GetString("BuildTaskCredProviderIsUsedError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials.
         /// </summary>
         internal static string BuildTaskEndpointEnvVarError {
             get {
                 return ResourceManager.GetString("BuildTaskEndpointEnvVarError", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to URL {0} did not have credentials stored in the environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS..
+        /// </summary>
+        internal static string BuildTaskEndpointNoMatchingUrl {
+            get {
+                return ResourceManager.GetString("BuildTaskEndpointNoMatchingUrl", resourceCulture);
             }
         }
         

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -560,6 +560,15 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Caught exception processing {0}  (RequestId: {1}).
+        /// </summary>
+        internal static string ResponseHandlerException {
+            get {
+                return ResourceManager.GetString("ResponseHandlerException", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Running in plug-in mode.
         /// </summary>
         internal static string RunningInPlugin {

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -176,7 +176,7 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This credential provider must not run if build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS.
+        ///   Looks up a localized string similar to This credential provider must not run if any build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS.
         /// </summary>
         internal static string BuildTaskCredProviderIsUsedError {
             get {
@@ -185,7 +185,7 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials.
+        ///   Looks up a localized string similar to This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials. Appropriate environment variable needs to be set..
         /// </summary>
         internal static string BuildTaskEndpointEnvVarError {
             get {
@@ -212,7 +212,7 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to This credential provider must be run under the Team Build tasks for NuGet.
+        ///   Looks up a localized string similar to This credential provider must be run under the Team Build tasks for NuGet. Appropriate environment variables must be set..
         /// </summary>
         internal static string BuildTaskEnvVarError {
             get {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -127,7 +127,14 @@
     <value>Failed to acquire session token: {0}</value>
   </data>
   <data name="AdalDeviceFlowMessage" xml:space="preserve">
-    <value>To sign in, use a web browser to open the page {0} and enter the code {1} to authenticate.</value>
+    <value>ATTENTION: User interaction required. 
+
+    **********************************************************************
+
+    To sign in, use a web browser to open the page {0} and enter the code {1} to authenticate.
+
+    **********************************************************************
+</value>
   </data>
   <data name="AdalDeviceFlowRequestedResource" xml:space="preserve">
     <value>DeviceFlow: {0}</value>
@@ -144,7 +151,7 @@
   <data name="BuildTaskEnvVarError" xml:space="preserve">
     <value>This credential provider must be run under the Team Build tasks for NuGet</value>
   </data>
-  <data name="BuildTaskIsRetry" xml:space="preserve">
+  <data name="BuildTaskFailedToAuthenticate" xml:space="preserve">
     <value>Failed to authenticate to {0} from your project collection</value>
   </data>
   <data name="BuildTaskMatchedPrefix" xml:space="preserve">
@@ -397,6 +404,12 @@ Device Flow Authentication Timeout
     <value>This credential provider must not run if build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS</value>
   </data>
   <data name="BuildTaskEndpointNoMatchingUrl" xml:space="preserve">
-    <value>URL {0} did not have credentials stored in the environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS.</value>
+    <value>Environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS did not have credentials for endpoint {0}</value>
+  </data>
+  <data name="BuildTaskEndpointMatchingUrlFound" xml:space="preserve">
+    <value>Found credentials for endpoint {0}</value>
+  </data>
+  <data name="CancelMessage" xml:space="preserve">
+    <value>Canceling credential provider</value>
   </data>
 </root>

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -149,7 +149,7 @@
     <value>Using AAD authority: {0}</value>
   </data>
   <data name="BuildTaskEnvVarError" xml:space="preserve">
-    <value>This credential provider must be run under the Team Build tasks for NuGet</value>
+    <value>This credential provider must be run under the Team Build tasks for NuGet. Appropriate environment variables must be set.</value>
   </data>
   <data name="BuildTaskFailedToAuthenticate" xml:space="preserve">
     <value>Failed to authenticate to {0} from your project collection</value>
@@ -374,7 +374,7 @@ Device Flow Authentication Timeout
     <value>Error happened while parsing json: {0}</value>
   </data>
   <data name="BuildTaskEndpointEnvVarError" xml:space="preserve">
-    <value>This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials</value>
+    <value>This credential provider must be run under the Team Build tasks for NuGet with external endpoint credentials. Appropriate environment variable needs to be set.</value>
   </data>
   <data name="AcquireBearerTokenSuccess" xml:space="preserve">
     <value>Acquired bearer token using '{0}'</value>
@@ -401,7 +401,7 @@ Device Flow Authentication Timeout
     <value>Could not parse Device Flow Timeout override: {0}</value>
   </data>
   <data name="BuildTaskCredProviderIsUsedError" xml:space="preserve">
-    <value>This credential provider must not run if build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS</value>
+    <value>This credential provider must not run if any build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS</value>
   </data>
   <data name="BuildTaskEndpointNoMatchingUrl" xml:space="preserve">
     <value>Environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS did not have credentials for endpoint {0}</value>

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -412,4 +412,7 @@ Device Flow Authentication Timeout
   <data name="CancelMessage" xml:space="preserve">
     <value>Canceling credential provider</value>
   </data>
+  <data name="ResponseHandlerException" xml:space="preserve">
+    <value>Caught exception processing {0}  (RequestId: {1})</value>
+  </data>
 </root>

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -393,4 +393,10 @@ Device Flow Authentication Timeout
   <data name="CouldNotParseDeviceFlowTimeoutOverride" xml:space="preserve">
     <value>Could not parse Device Flow Timeout override: {0}</value>
   </data>
+  <data name="BuildTaskCredProviderIsUsedError" xml:space="preserve">
+    <value>This credential provider must not run if build task environment variables are set. Variables: VSS_NUGET_URI_PREFIXES, VSS_NUGET_ACCESSTOKEN, VSS_NUGET_EXTERNAL_FEED_ENDPOINTS</value>
+  </data>
+  <data name="BuildTaskEndpointNoMatchingUrl" xml:space="preserve">
+    <value>URL {0} did not have credentials stored in the environment variable VSS_NUGET_EXTERNAL_FEED_ENDPOINTS.</value>
+  </data>
 </root>


### PR DESCRIPTION
- Add more logging
- Only try cache if cred provider is cachable
- Remove IsRetry check from build task cred providers
- In build task cred providers, move all checks but environment variable checks from CanProvideCredentials to HandleRequest
- Only use VstsCredentialProvider if build task env vars are not set
- Make the actionable device flow console message easier to see
![image](https://user-images.githubusercontent.com/24945574/51000482-1f314d80-14e2-11e9-8e9d-0533560f88d3.png)
- Add special cancellation handling to fix a "message type 'Cancel' is invalid at this time" issue