### PR TITLE
Catch an exception when reading cache

### DIFF
--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -127,7 +127,7 @@ namespace NuGetCredentialProvider.RequestHandlers
             if (EnvUtil.SessionTokenCacheEnabled())
             {
                 logger.Verbose(string.Format(Resources.SessionTokenCacheLocation, EnvUtil.SessionTokenCacheLocation));
-                return new SessionTokenCache(EnvUtil.SessionTokenCacheLocation);
+                return new SessionTokenCache(EnvUtil.SessionTokenCacheLocation, logger);
             }
 
             logger.Verbose(Resources.SessionTokenCacheDisabled);
@@ -145,7 +145,7 @@ namespace NuGetCredentialProvider.RequestHandlers
                 cache?.Remove(request.Uri);
                 return false;
             }
-            else if (cache.TryGetValue(request.Uri, Logger, out string password))
+            else if (cache.TryGetValue(request.Uri, out string password))
             {
                 Logger.Verbose(string.Format(Resources.FoundCachedSessionToken, request.Uri.ToString()));
                 cachedToken = password;

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -266,7 +266,7 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Exception happened when trying to get cached token: invalidating cache. Message: {0}.
+        ///   Looks up a localized string similar to Exception happened when trying to get cached token. Invalidating cache. Message: {0}.
         /// </summary>
         internal static string CacheException {
             get {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -416,6 +416,6 @@ Device Flow Authentication Timeout
     <value>Caught exception processing {0}  (RequestId: {1})</value>
   </data>
   <data name="CacheException" xml:space="preserve">
-    <value>Exception happened when trying to get cached token: invalidating cache. Message: {0}</value>
+    <value>Exception happened when trying to get cached token. Invalidating cache. Message: {0}</value>
   </data>
 </root>

--- a/CredentialProvider.Microsoft/Util/ICache.cs
+++ b/CredentialProvider.Microsoft/Util/ICache.cs
@@ -2,8 +2,6 @@
 //
 // Licensed under the MIT license.
 
-using NuGetCredentialProvider.Logging;
-
 namespace NuGetCredentialProvider.Util
 {
     public interface ICache<TKey, TValue>
@@ -12,7 +10,7 @@ namespace NuGetCredentialProvider.Util
 
         bool ContainsKey(TKey key);
 
-        bool TryGetValue(TKey key, ILogger logger, out TValue value);
+        bool TryGetValue(TKey key, out TValue value);
 
         void Remove(TKey key);
     }
@@ -36,7 +34,7 @@ namespace NuGetCredentialProvider.Util
         {
         }
 
-        public bool TryGetValue(TKey key, ILogger logger, out TValue value)
+        public bool TryGetValue(TKey key, out TValue value)
         {
             value = default;
 

--- a/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
+++ b/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
@@ -14,9 +14,12 @@ namespace NuGetCredentialProvider.Util
     {
         private static readonly object FileLock = new object();
         private readonly string cacheFilePath;
-        public SessionTokenCache(string cacheFilePath)
+        private ILogger logger;
+
+        public SessionTokenCache(string cacheFilePath, ILogger logger)
         {
             this.cacheFilePath = cacheFilePath;
+            this.logger = logger;
         }
 
         private Dictionary<Uri, string> Cache
@@ -49,7 +52,7 @@ namespace NuGetCredentialProvider.Util
             return Cache.ContainsKey(key);
         }
 
-        public bool TryGetValue(Uri key, ILogger logger, out string value)
+        public bool TryGetValue(Uri key, out string value)
         {
             try
             {
@@ -59,12 +62,11 @@ namespace NuGetCredentialProvider.Util
             {
                 if (File.Exists(cacheFilePath))
                 {
-                    logger.Verbose(string.Format(Resources.CacheException, e.Message));
-
                     File.Delete(cacheFilePath);
-                    Cache.Remove(key);
                 }
 
+                logger.Verbose(string.Format(Resources.CacheException, e.Message));
+                Cache.Clear();
                 value = null;
 
                 return false;


### PR DESCRIPTION
Fixes [#46](https://github.com/Microsoft/artifacts-credprovider/issues/46) by removing the cached token on exception.