### PR TITLE
Clarify that the --interactive step can be avoided

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ dotnet restore --interactive
 
 Once you've successfully acquired a token, you can run authenticated commands without the `--interactive` flag for the lifespan of the token which is saved in the [session token cache location](#session-token-cache-locations).
 
+If you need to avoid this initial interactive step (e.g., because you are running the command as part of an automated build on an unattended build agent), you can supply an access token directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment variables).
+
 ### nuget
 
 The nuget client will prompt for authentication when you run a `restore` and it does not find credential in the [session token cache location](#session-token-cache-locations). By default, it will attempt to open a dialog for authentication and will fall back to console input if that fails.

--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Because the Credential Provider is a NuGet plugin, it is most commonly used indi
 
 ### dotnet
 
-The first time you perform an operation that requires authentication using `dotnet`, you must use the `--interactive` flag to allow `dotnet` to prompt you for credentials. For example, to restore packages, navigate to your project directory and run:
+The first time you perform an operation that requires authentication using `dotnet`, you must either use the `--interactive` flag to allow `dotnet` to prompt you for credentials, or provide them via an environment variable. 
+
+If you're running interactively navigate to your project directory and run:
 
 ```shell
 dotnet restore --interactive
@@ -68,7 +70,7 @@ dotnet restore --interactive
 
 Once you've successfully acquired a token, you can run authenticated commands without the `--interactive` flag for the lifespan of the token which is saved in the [session token cache location](#session-token-cache-locations).
 
-If you need to avoid this initial interactive step (e.g., because you are running the command as part of an automated build on an unattended build agent), you can supply an access token directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment variables).
+If you're running the command as part of an automated build on an unattended build agent, you can supply an access token directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment-variables).
 
 ### nuget
 


### PR DESCRIPTION
The section that describes running an initial `dotnet restore --interactive` command to acquire a token is worded in a way that implies that this step is mandatory. In fact it isn't because it is also possible to use the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` environment variable to supply you own access token if you already have one in hand.

It was really easy to miss that because the first section makes it sound like only interactive operation is supported, and even if that doesn't put you off and you continue to look for a way, there's nothing in either the "Environment Variables" title or the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` variable name to give you a clear clue that this provides a way to bypass interactive operation.

By adding an extra paragraph directly after the description of the interactive process, it is easier for readers to discover that an alternative exists.