### PR TITLE
use named mutex instead of lock to lock cache file

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>0.1.13</CredentialProviderVersion>
+    <CredentialProviderVersion>0.1.14</CredentialProviderVersion>
   </PropertyGroup>
 </Project>

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -115,7 +115,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
         }
 
         [TestMethod]
-        public async Task HandleRequestAsync_ThrowsWithInvalidJson()
+        public void HandleRequestAsync_ThrowsWithInvalidJson()
         {
             Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json");
             string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
@@ -123,7 +123,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
 
             Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, invalidFeedEndPointJson);
 
-            Action act = () => vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Func<Task> act = async () => await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
             act.Should().Throw<Exception>();
         }
     }

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -39,7 +39,7 @@ namespace NuGetCredentialProvider.RequestHandlers
         public GetAuthenticationCredentialsRequestHandler(ILogger logger, IReadOnlyCollection<ICredentialProvider> credentialProviders)
             : this(logger, credentialProviders, null)
         {
-            this.cache = GetSessionTokenCache(logger);
+            this.cache = GetSessionTokenCache(logger, CancellationToken);
         }
 
         public override async Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request)
@@ -122,12 +122,12 @@ namespace NuGetCredentialProvider.RequestHandlers
             return AutomaticProgressReporter.Create(connection, message, progressReporterTimeSpan, cancellationToken);
         }
 
-        private static ICache<Uri, string> GetSessionTokenCache(ILogger logger)
+        private static ICache<Uri, string> GetSessionTokenCache(ILogger logger, CancellationToken cancellationToken)
         {
             if (EnvUtil.SessionTokenCacheEnabled())
             {
                 logger.Verbose(string.Format(Resources.SessionTokenCacheLocation, EnvUtil.SessionTokenCacheLocation));
-                return new SessionTokenCache(EnvUtil.SessionTokenCacheLocation, logger);
+                return new SessionTokenCache(EnvUtil.SessionTokenCacheLocation, logger, cancellationToken);
             }
 
             logger.Verbose(Resources.SessionTokenCacheDisabled);

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -641,6 +641,24 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Unable to gain a lock on the credential cache..
+        /// </summary>
+        internal static string SessionTokenCacheMutexFail {
+            get {
+                return ResourceManager.GetString("SessionTokenCacheMutexFail", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Another instance of CredentialProvider is accessing the credential cache, waiting for it to become available..
+        /// </summary>
+        internal static string SessionTokenCacheMutexMiss {
+            get {
+                return ResourceManager.GetString("SessionTokenCacheMutexMiss", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Credential provider shutting down..
         /// </summary>
         internal static string ShuttingDown {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -433,4 +433,10 @@ Device Flow Authentication Timeout
   <data name="TimeElapsedAfterSendingResponse" xml:space="preserve">
     <value>Time elapsed in milliseconds after sending response '{0}' '{1}': {2}</value>
   </data>
+  <data name="SessionTokenCacheMutexFail" xml:space="preserve">
+    <value>Unable to gain a lock on the credential cache.</value>
+  </data>
+  <data name="SessionTokenCacheMutexMiss" xml:space="preserve">
+    <value>Another instance of CredentialProvider is accessing the credential cache, waiting for it to become available.</value>
+  </data>
 </root>


### PR DESCRIPTION
At the moment we're using lock to control access to the credential cache file, but that doesn't work if multiple instances are running. Updated to use a named mutex. If there is a timeout acquiring the lock, the credential provider will log a verbose message and continue.

#74