### PR TITLE
Make Linux/Mac install helper more robust

### DIFF
--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -14,7 +14,7 @@ NUGET_PLUGIN_DIR="$HOME/.nuget/plugins"
 # Ensure plugin directory exists
 if [[ ! -e ${NUGET_PLUGIN_DIR} ]]; then
   echo "INFO: Creating the nuget plugin directory (i.e. ${NUGET_PLUGIN_DIR}). "
-  if ! mkdir -p ${NUGET_PLUGIN_DIR}; then
+  if ! mkdir -p "${NUGET_PLUGIN_DIR}"; then
       echo "ERROR: Unable to create nuget plugins directory (i.e. ${NUGET_PLUGIN_DIR})."
       exit 1
   fi
@@ -27,6 +27,6 @@ echo "Downloading from $URI"
 curl -H "Accept: application/octet-stream" \
      -s \
      -L \
-     $URI | tar xz -C $HOME/.nuget/ plugins/netcore
+     "$URI" | tar xz -C "$HOME/.nuget/" "plugins/netcore"
 
 echo "INFO: credential provider netcore plugin extracted to $HOME/.nuget/"

--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -26,6 +26,7 @@ echo "Downloading from $URI"
 #Fetch the file
 curl -H "Accept: application/octet-stream" \
      -s \
+     -S \
      -L \
      "$URI" | tar xz -C "$HOME/.nuget/" "plugins/netcore"
 


### PR DESCRIPTION
The install script does not work by default at my Arch Linux system. It assumes `python` means Python 2, but it means Python 3 at some systems. This pull request features a bug fix for this.

After looking at it a bit, I noticed that several shell script best practices are not implemented. As the shell script enthusiast I am, I thought I'd contribute a couple improvements :smile: Mainly suggestions from the tool [shellcheck](https://www.shellcheck.net/).