### PR TITLE
Fix cache location on linux: LocalApplicationData folder may not exist

### DIFF
--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -30,7 +30,7 @@ namespace NuGetCredentialProvider.Util
         public const string BuildTaskAccessToken = "VSS_NUGET_ACCESSTOKEN";
         public const string BuildTaskExternalEndpoints = "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS";
 
-        private static readonly string LocalAppDataLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "MicrosoftCredentialProvider");
+        private static readonly string LocalAppDataLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData, Environment.SpecialFolderOption.Create), "MicrosoftCredentialProvider");
 
         public static string AdalTokenCacheLocation { get; } = Path.Combine(LocalAppDataLocation, "ADALTokenCache.dat");
 


### PR DESCRIPTION
On many linux distros, `Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData)` returns an empty string since ~/.local/share doesn't exist (see https://github.com/dotnet/corefx/issues/32716). Because it was empty, the MicrosoftCredentialProvider / cache was being placed in the current working directory.

As per the linked issue, SpecialFolderOption.Create solves the issue by creating it if it does not exist.