### PR TITLE
Allow running on .NET Core 3.x

### DIFF
--- a/CredentialProvider.Microsoft/runtimeconfig.template.json
+++ b/CredentialProvider.Microsoft/runtimeconfig.template.json
@@ -1,0 +1,3 @@
+{
+  "rollForward": "Major"
+}


### PR DESCRIPTION
Currently, 'dotnet restore' fails to run the credprovider if only .NET Core 3.x runtime is available.
This change allows the credprovider to run even if only 3.x is available.
See https://natemcmaster.com/blog/2019/01/09/netcore-primitives-3 for details.

Solves/alternative to #112 and addresses https://github.com/dotnet/arcade/issues/3320