### PR TITLE
Fix Unhandled TaskCanceledException

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -126,5 +126,21 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
             Func<Task> act = async () => await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
             act.Should().Throw<Exception>();
         }
+
+        [TestMethod]
+        public async Task HandleRequestAsync_MatchesEndpointURLCaseInsensitive()
+        {
+            Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me/_Packaging/TestFEED/nuget/v3/index.json");
+
+            string feedEndPointJson = "{\"endpointCredentials\":[{\"endpoint\":\"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser\", \"password\":\"testToken\"}]}";
+            string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
+
+            Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, feedEndPointJson);
+
+            var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Assert.AreEqual(MessageResponseCode.Success, result.ResponseCode);
+            Assert.AreEqual("testUser", result.Username);
+            Assert.AreEqual("testToken", result.Password);
+        }
     }
 }

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
-    <PackageReference Include="NuGet.Protocol" Version="4.8.0-preview5.5326" />
+    <PackageReference Include="NuGet.Protocol" Version="5.2.0" />
     <PackageReference Include="PowerArgs" Version="3.0.0" />
   </ItemGroup>
 

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -108,7 +108,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
             {
                 // Parse JSON from VSS_NUGET_EXTERNAL_FEED_ENDPOINTS
                 Verbose(Resources.ParsingJson);
-                Dictionary<string, EndpointCredentials> credsResult = new Dictionary<string, EndpointCredentials>();
+                Dictionary<string, EndpointCredentials> credsResult = new Dictionary<string, EndpointCredentials>(StringComparer.OrdinalIgnoreCase);
                 EndpointCredentialsContainer endpointCredentials = JsonConvert.DeserializeObject<EndpointCredentialsContainer>(feedEndPointsJson);
                 if (endpointCredentials == null)
                 {

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -10,6 +10,7 @@ using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
+using NuGet.Common;
 using NuGet.Protocol.Plugins;
 using NuGetCredentialProvider.CredentialProviders;
 using NuGetCredentialProvider.CredentialProviders.Vsts;
@@ -142,10 +143,11 @@ namespace NuGetCredentialProvider
                             await RunNuGetPluginsAsync(plugin, multiLogger, TimeSpan.FromMinutes(2), tokenSource.Token).ConfigureAwait(continueOnCapturedContext: false);
                         }
                     }
-                    catch (TaskCanceledException)
+                    catch (OperationCanceledException ex)
                     {
                         // When restoring from multiple sources, one of the sources will throw an unhandled TaskCanceledException
-                        // if it has been restored successfully from a different source. We catch the exception and silently exit.
+                        // if it has been restored successfully from a different source.
+                        multiLogger.Log(LogLevel.Verbose, ex.ToString());
                     }
 
                     return 0;

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Install [Visual Studio version 15.9-preview1 or later](https://visualstudio.micr
 
 ## Setup
 
-If you are using `dotnet` or `nuget`, you can use the Azure Artifact Credential Provider by adding it to [NuGet's plugin search path](https://github.com/NuGet/Home/wiki/NuGet-Cross-Plat-Credential-Plugin#plugin-installation-and-discovery). This section contains both manual and scripted instructions for doing so.
+If you are using `dotnet` or `nuget`, you can use the Azure Artifact Credential Provider by adding it to [NuGet's plugin search path](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery). This section contains both manual and scripted instructions for doing so.
 
 ### Installation on Windows
 
@@ -44,7 +44,7 @@ If you are using `dotnet` or `nuget`, you can use the Azure Artifact Credential 
 2. Unzip the file
 3. Copy the `netcore` (and `netfx` for nuget.exe) directory from the extracted archive to `$env:UserProfile\.nuget\plugins`
 
-Using the above is recommended, but as per [NuGet's plugin discovery rules](https://github.com/NuGet/Home/wiki/NuGet-Cross-Plat-Credential-Plugin#plugin-installation-and-discovery), alternatively you can install the credential provider to a location you prefer, and then set the environment variable NUGET_PLUGIN_PATHS to the .exe of the credential provider found in plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe. For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.exe". Note that if you are using both nuget and dotnet, this environment variable is not recommended due to this issue: https://github.com/NuGet/Home/issues/8151
+Using the above is recommended, but as per [NuGet's plugin discovery rules](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery), alternatively you can install the credential provider to a location you prefer, and then set the environment variable NUGET_PLUGIN_PATHS to the .exe of the credential provider found in plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe. For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.exe". Note that if you are using both nuget and dotnet, this environment variable is not recommended due to this issue: https://github.com/NuGet/Home/issues/8151
 
 ### Installation on Linux and Mac
 
@@ -58,7 +58,12 @@ Using the above is recommended, but as per [NuGet's plugin discovery rules](http
 2. Untar the file
 3. Copy the `netcore` directory from the extracted archive to `$HOME\.nuget\plugins`
 
-Using the above is recommended, but as per [NuGet's plugin discovery rules](https://github.com/NuGet/Home/wiki/NuGet-Cross-Plat-Credential-Plugin#plugin-installation-and-discovery), alternatively you can install the credential provider to a location you prefer, and then set the environment variable NUGET_PLUGIN_PATHS to the .dll of the credential provider found in plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll. For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.dll".
+Using the above is recommended, but as per [NuGet's plugin discovery rules](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery), alternatively you can install the credential provider to a location you prefer, and then set the environment variable NUGET_PLUGIN_PATHS to the .dll of the credential provider found in plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll. For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.dll".
+
+### Automatic usage
+- MSBuild in Visual Studio Developer Command Prompt with Visual Studio 15.9+
+- Azure DevOps Pipelines NuGet tasks (NuGetCommandV2) version 2.145.3+
+- NuGet tasks in Azure DevOps Server 2019 Update 1+
 
 ## Use
 
@@ -101,6 +106,9 @@ Once you've successfully acquired a token, you can run authenticated commands wi
 If you're running the command as part of an automated build on an unattended build agent, you can supply an access token directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment-variables). The use of [Personal Access Tokens](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) is recommended.
 
 You may need to restart the agent service or the computer before the environment variables are available to the agent.
+
+### Docker containers
+[Sample Dockerfile](https://github.com/microsoft/artifacts-credprovider/blob/master/samples/dockerfile.sample.txt)
 
 ## Session Token Cache Locations
 

--- a/samples/dockerfile.sample.txt
+++ b/samples/dockerfile.sample.txt
@@ -1,0 +1,28 @@
+# downloading the dotnet sdk image. Could be any docker sdk image with sdk > 2.1.500
+FROM microsoft/dotnet:2.1-sdk AS dotnet-builder
+ARG FEED_URL
+ARG PAT
+
+# download and install latest credential provider. Not required after https://github.com/dotnet/dotnet-docker/issues/878
+RUN wget -qO- https://raw.githubusercontent.com/Microsoft/artifacts-credprovider/master/helpers/installcredprovider.sh | bash
+
+# Optional
+WORKDIR /workdir
+COPY ./ .
+
+# Optional: Sometimes the http client hangs because of a .NEt issue. Setting this in dockerfile helps 
+ENV DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER=0
+
+# Environment variable to enable seesion token cache. More on this here: https://github.com/Microsoft/artifacts-credprovider#help
+ENV NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED true
+
+# Environment variable for adding endpoint credentials. More on this here: https://github.com/Microsoft/artifacts-credprovider#help
+# Add "FEED_URL" AND "PAT" using --build-arg in docker build step. "endpointCredentials" field is an array, you can add multiple endpoint configurations.
+# Make sure that you *do not* hard code the "PAT" here. That is a sensitive information and must not be checked in.
+ENV VSS_NUGET_EXTERNAL_FEED_ENDPOINTS {\"endpointCredentials\": [{\"endpoint\":\"${FEED_URL}\", \"username\":\"ArtifactsDocker\", \"password\":\"${PAT}\"}]}
+
+# Use this if you have a nuget.config file with all the endpoints.
+RUN dotnet restore
+
+# Optional: Extended step to build the app using dotnet msbuild. 
+RUN dotnet build dirs.proj


### PR DESCRIPTION
Hey team,

This is a fix for my issue  https://github.com/microsoft/artifacts-credprovider/issues/108

I've taken @dtivel's suggestion of wrapping a block of code in `Program.cs` to catch an unhandled `TaskCanceledException`. 

I ran the unit tests in the project and all but two tests pass. The two that fail are:
```
CanProvideCredentials_ReturnsTrueForKnownSources()
CanProvideCredentials_ReturnsTrueForOverridenSources()
```

However, these tests also fail when running against the latest in `master`. 

As far as I can tell, my issue can only be replicated in a docker container. I've ran some before and after tests using the latest version of the cred provider, and a copy of the cred provider after I have made my change. I no longer receive the error:

```
Unhandled Exception: System.Threading.Tasks.TaskCanceledException: A task was canceled.`
```

However, I am now seeing about 5 warnings similar to this:

```
The HTTP request to 'GET https://pkgs.dev.azure.com/{company}/_packaging/47a1753d-0296-432f-95f2-2f9e908f3e8f/nuget/v3/flat2/microsoft.aspnetcore.http.abstractions/index.json' has timed out after 100000ms.
```

But it doesn't appear to be causing the build to fail. I also want to mention that the error is likely because we don't have upstream sources enabled, and it's likely a `dotnet restore` bug causing the timeouts. 

Looking forward to any advice to improve my submission and having this merged & released so we can move forward with Azure Artifacts 😄 

Thanks!