### PR TITLE
Update NuGet.Protocol dependency to 5.2.0

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -33,7 +33,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="3.19.4" />
-    <PackageReference Include="NuGet.Protocol" Version="4.8.0-preview5.5326" />
+    <PackageReference Include="NuGet.Protocol" Version="5.2.0" />
     <PackageReference Include="PowerArgs" Version="3.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Suggested by @dtivel to get [Plugin Diagnostic Logging](https://github.com/NuGet/Home/wiki/Plugin-Diagnostic-Logging) on the credprovider side, not just the nuget side. Thanks!