### PR TITLE
Return non-zero exit code when credentials are not successfully acquired

### DIFF
--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -182,6 +182,12 @@ namespace NuGetCredentialProvider
                     GetAuthenticationCredentialsRequest request = new GetAuthenticationCredentialsRequest(parsedArgs.Uri, isRetry: parsedArgs.IsRetry, isNonInteractive: parsedArgs.NonInteractive, parsedArgs.CanShowDialog);
                     GetAuthenticationCredentialsResponse response = await getAuthenticationCredentialsRequestHandler.HandleRequestAsync(request).ConfigureAwait(continueOnCapturedContext: false);
 
+                    // Fail if credentials are not found
+                    if (response?.ResponseCode != MessageResponseCode.Success)
+                    {
+                        return 2;
+                    }
+
                     string resultUsername = response?.Username;
                     string resultPassword = parsedArgs.RedactPassword ? Resources.Redacted : response?.Password;
                     if (parsedArgs.OutputFormat == OutputFormat.Json)

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -108,6 +108,7 @@ namespace NuGetCredentialProvider.RequestHandlers
                 }
             }
 
+            Logger.Verbose(Resources.CredentialsNotFound);
             return new GetAuthenticationCredentialsResponse(
                 username: null,
                 password: null,

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -365,6 +365,15 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Credentials not found..
+        /// </summary>
+        internal static string CredentialsNotFound {
+            get {
+                return ResourceManager.GetString("CredentialsNotFound", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Device flow authentication failed. User was presented with device flow, but didn&apos;t react within {0} seconds..
         /// </summary>
         internal static string DeviceFlowTimedOut {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -446,6 +446,6 @@ Device Flow Authentication Timeout
     <value>While the plugin was shutting down:</value>
   </data>
   <data name="CredentialsNotFound" xml:space="preserve">
-    <value>Credentials not found.</value>
+    <value>Unable to acquire credentials.</value>
   </data>
 </root>

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -445,4 +445,7 @@ Device Flow Authentication Timeout
   <data name="WhileShuttingDown" xml:space="preserve">
     <value>While the plugin was shutting down:</value>
   </data>
+  <data name="CredentialsNotFound" xml:space="preserve">
+    <value>Credentials not found.</value>
+  </data>
 </root>


### PR DESCRIPTION
Fixes #167 