### PR TITLE
Fixed the URL Encoding used in the logs and the prefix comparison

### DIFF
--- a/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
+++ b/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
@@ -17,7 +17,7 @@ namespace CredentialProvider.Microsoft.Tests.Logging
             mockWriter.Setup(x => x.WriteLine(It.IsAny<string>()));
             HumanFriendlyTextWriterLogger logger = new HumanFriendlyTextWriterLogger(mockWriter.Object, writesToConsole: false);
             logger.SetLogLevel(LogLevel.Error);
-            logger.Log(LogLevel.Error, true, "Something bad happened");
+            logger.Log(LogLevel.Error, allowOnConsole: true, message: "Something bad happened");
             mockWriter.Verify(x => x.WriteLine("[Error] [CredentialProvider]Something bad happened"));
         }
     }

--- a/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
+++ b/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
@@ -17,7 +17,7 @@ namespace CredentialProvider.Microsoft.Tests.Logging
             mockWriter.Setup(x => x.WriteLine(It.IsAny<string>()));
             HumanFriendlyTextWriterLogger logger = new HumanFriendlyTextWriterLogger(mockWriter.Object, writesToConsole: false);
             logger.SetLogLevel(LogLevel.Error);
-            logger.Log(LogLevel.Error, allowOnConsole: true, "Something bad happened");
+            logger.Log(LogLevel.Error, true, "Something bad happened");
             mockWriter.Verify(x => x.WriteLine("[Error] [CredentialProvider]Something bad happened"));
         }
     }

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -115,7 +115,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
                     if (!string.IsNullOrWhiteSpace(sessionToken))
                     {
-                        Verbose(string.Format(Resources.VSTSSessionTokenCreated, request.Uri.AbsoluteUri.ToString()));
+                        Verbose(string.Format(Resources.VSTSSessionTokenCreated, request.Uri.AbsoluteUri));
                         return new GetAuthenticationCredentialsResponse(
                             Username,
                             sessionToken,
@@ -130,7 +130,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 }
             }
 
-            Verbose(string.Format(Resources.VSTSCredentialsNotFound, request.Uri.AbsoluteUri.ToString()));
+            Verbose(string.Format(Resources.VSTSCredentialsNotFound, request.Uri.AbsoluteUri));
             return null;
         }
     }

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -115,7 +115,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
                     if (!string.IsNullOrWhiteSpace(sessionToken))
                     {
-                        Verbose(string.Format(Resources.VSTSSessionTokenCreated, request.Uri.ToString()));
+                        Verbose(string.Format(Resources.VSTSSessionTokenCreated, request.Uri.AbsoluteUri.ToString()));
                         return new GetAuthenticationCredentialsResponse(
                             Username,
                             sessionToken,
@@ -126,11 +126,11 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 }
                 catch (Exception e)
                 {
-                    Verbose(string.Format(Resources.VSTSCreateSessionException, request.Uri, e.Message, e.StackTrace));
+                    Verbose(string.Format(Resources.VSTSCreateSessionException, request.Uri.AbsoluteUri, e.Message, e.StackTrace));
                 }
             }
 
-            Verbose(string.Format(Resources.VSTSCredentialsNotFound, request.Uri.ToString()));
+            Verbose(string.Format(Resources.VSTSCredentialsNotFound, request.Uri.AbsoluteUri.ToString()));
             return null;
         }
     }

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
@@ -58,7 +58,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTask
                 Verbose($"{uriPrefix}");
             }
 
-            string uriString = request.Uri.AbsoluteUri.ToString();
+            string uriString = request.Uri.AbsoluteUri;
             string matchedPrefix = uriPrefixes.FirstOrDefault(prefix => uriString.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
             Verbose(string.Format(Resources.BuildTaskMatchedPrefix, matchedPrefix != null  ? matchedPrefix : Resources.BuildTaskNoMatchingPrefixes));
 

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTask/VstsBuildTaskCredentialProvider.cs
@@ -58,7 +58,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTask
                 Verbose($"{uriPrefix}");
             }
 
-            string uriString = request.Uri.ToString();
+            string uriString = request.Uri.AbsoluteUri.ToString();
             string matchedPrefix = uriPrefixes.FirstOrDefault(prefix => uriString.StartsWith(prefix, StringComparison.OrdinalIgnoreCase));
             Verbose(string.Format(Resources.BuildTaskMatchedPrefix, matchedPrefix != null  ? matchedPrefix : Resources.BuildTaskNoMatchingPrefixes));
 

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -67,7 +67,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
 
             Verbose(string.Format(Resources.IsRetry, request.IsRetry));
 
-            string uriString = request.Uri.ToString();
+            string uriString = request.Uri.AbsoluteUri.ToString();
             bool endpointFound = Credentials.TryGetValue(uriString, out EndpointCredentials matchingEndpoint);
             if (endpointFound)
             {

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -67,7 +67,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
 
             Verbose(string.Format(Resources.IsRetry, request.IsRetry));
 
-            string uriString = request.Uri.AbsoluteUri.ToString();
+            string uriString = request.Uri.AbsoluteUri;
             bool endpointFound = Credentials.TryGetValue(uriString, out EndpointCredentials matchingEndpoint);
             if (endpointFound)
             {

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -63,7 +63,7 @@ namespace NuGetCredentialProvider.RequestHandlers
             {
                 if (await credentialProvider.CanProvideCredentialsAsync(request.Uri) == false)
                 {
-                    Logger.Verbose(string.Format(Resources.SkippingCredentialProvider, credentialProvider, request.Uri.AbsoluteUri.ToString()));
+                    Logger.Verbose(string.Format(Resources.SkippingCredentialProvider, credentialProvider, request.Uri.AbsoluteUri));
                     continue;
                 }
 
@@ -84,7 +84,7 @@ namespace NuGetCredentialProvider.RequestHandlers
                     {
                         if (cache != null && credentialProvider.IsCachable)
                         {
-                            Logger.Verbose(string.Format(Resources.CachingSessionToken, request.Uri.AbsoluteUri.ToString()));
+                            Logger.Verbose(string.Format(Resources.CachingSessionToken, request.Uri.AbsoluteUri));
                             cache[request.Uri] = response.Password;
                         }
 
@@ -142,18 +142,18 @@ namespace NuGetCredentialProvider.RequestHandlers
             Logger.Verbose(string.Format(Resources.IsRetry, request.IsRetry));
             if (request.IsRetry)
             {
-                Logger.Verbose(string.Format(Resources.InvalidatingCachedSessionToken, request.Uri.AbsoluteUri.ToString()));
+                Logger.Verbose(string.Format(Resources.InvalidatingCachedSessionToken, request.Uri.AbsoluteUri));
                 cache?.Remove(request.Uri);
                 return false;
             }
             else if (cache.TryGetValue(request.Uri, out string password))
             {
-                Logger.Verbose(string.Format(Resources.FoundCachedSessionToken, request.Uri.AbsoluteUri.ToString()));
+                Logger.Verbose(string.Format(Resources.FoundCachedSessionToken, request.Uri.AbsoluteUri));
                 cachedToken = password;
                 return true;
             }
 
-            Logger.Verbose(string.Format(Resources.CachedSessionTokenNotFound, request.Uri.AbsoluteUri.ToString()));
+            Logger.Verbose(string.Format(Resources.CachedSessionTokenNotFound, request.Uri.AbsoluteUri));
             return false;
         }
     }

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -44,7 +44,7 @@ namespace NuGetCredentialProvider.RequestHandlers
 
         public override async Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request)
         {
-            Logger.Verbose(string.Format(Resources.HandlingAuthRequest, request.Uri, request.IsRetry, request.IsNonInteractive, request.CanShowDialog));
+            Logger.Verbose(string.Format(Resources.HandlingAuthRequest, request.Uri.AbsoluteUri, request.IsRetry, request.IsNonInteractive, request.CanShowDialog));
 
             if (request?.Uri == null)
             {
@@ -57,13 +57,13 @@ namespace NuGetCredentialProvider.RequestHandlers
                     responseCode: MessageResponseCode.Error);
             }
 
-            Logger.Verbose(string.Format(Resources.Uri, request.Uri));
+            Logger.Verbose(string.Format(Resources.Uri, request.Uri.AbsoluteUri));
 
             foreach (ICredentialProvider credentialProvider in credentialProviders)
             {
                 if (await credentialProvider.CanProvideCredentialsAsync(request.Uri) == false)
                 {
-                    Logger.Verbose(string.Format(Resources.SkippingCredentialProvider, credentialProvider, request.Uri.ToString()));
+                    Logger.Verbose(string.Format(Resources.SkippingCredentialProvider, credentialProvider, request.Uri.AbsoluteUri.ToString()));
                     continue;
                 }
 
@@ -84,7 +84,7 @@ namespace NuGetCredentialProvider.RequestHandlers
                     {
                         if (cache != null && credentialProvider.IsCachable)
                         {
-                            Logger.Verbose(string.Format(Resources.CachingSessionToken, request.Uri.ToString()));
+                            Logger.Verbose(string.Format(Resources.CachingSessionToken, request.Uri.AbsoluteUri.ToString()));
                             cache[request.Uri] = response.Password;
                         }
 
@@ -142,18 +142,18 @@ namespace NuGetCredentialProvider.RequestHandlers
             Logger.Verbose(string.Format(Resources.IsRetry, request.IsRetry));
             if (request.IsRetry)
             {
-                Logger.Verbose(string.Format(Resources.InvalidatingCachedSessionToken, request.Uri.ToString()));
+                Logger.Verbose(string.Format(Resources.InvalidatingCachedSessionToken, request.Uri.AbsoluteUri.ToString()));
                 cache?.Remove(request.Uri);
                 return false;
             }
             else if (cache.TryGetValue(request.Uri, out string password))
             {
-                Logger.Verbose(string.Format(Resources.FoundCachedSessionToken, request.Uri.ToString()));
+                Logger.Verbose(string.Format(Resources.FoundCachedSessionToken, request.Uri.AbsoluteUri.ToString()));
                 cachedToken = password;
                 return true;
             }
 
-            Logger.Verbose(string.Format(Resources.CachedSessionTokenNotFound, request.Uri.ToString()));
+            Logger.Verbose(string.Format(Resources.CachedSessionTokenNotFound, request.Uri.AbsoluteUri.ToString()));
             return false;
         }
     }


### PR DESCRIPTION
Fixed the encoding to properly match URIs containing spaces in both the prefix matching and in the logs.