### PR TITLE
Allow disabling DeviceFlow authentication using an environment variable

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/BearerTokenProviders.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/BearerTokenProviders.cs
@@ -133,7 +133,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public bool ShouldRun(bool isRetry, bool isNonInteractive, bool canShowDialog)
         {
-            return !isNonInteractive;
+            return !isNonInteractive && EnvUtil.DeviceFlowAuthenticationEnabled();
         }
     }
 

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -124,6 +124,7 @@ namespace NuGetCredentialProvider
                             EnvUtil.AdalTokenCacheLocation,
                             EnvUtil.SessionTokenCacheLocation,
                             EnvUtil.WindowsIntegratedAuthenticationEnvVar,
+                            EnvUtil.DeviceFlowAuthenticationEnvVar,
                             EnvUtil.DeviceFlowTimeoutEnvVar,
                             EnvUtil.ForceCanShowDialogEnvVar
                         ));

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetCredentialProvider {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -348,12 +348,17 @@ Windows Integrated Authentication
         Boolean to enable/disable using silent Windows Integrated Authentication
         to authenticate as the logged-in user. Enabled by default.
 
-Device Flow Authentication Timeout
+Device Flow Authentication
     {14}
+        Boolean to enable/disable using Device Flow Authentication
+        to authenticate as the logged-in user. Enabled by default.
+
+Device Flow Authentication Timeout
+    {15}
         Device Flow authentication timeout in seconds. Default is 90 seconds.
 
 NuGet workarounds
-    {15}
+    {16}
         Set to "true" or "false" to override any other sources of the 
         CanShowDialog parameter</value>
   </data>

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -16,6 +16,7 @@ namespace NuGetCredentialProvider.Util
         public const string LogPathEnvVar = "NUGET_CREDENTIALPROVIDER_LOG_PATH";
         public const string SessionTokenCacheEnvVar = "NUGET_CREDENTIALPROVIDER_SESSIONTOKENCACHE_ENABLED";
         public const string WindowsIntegratedAuthenticationEnvVar = "NUGET_CREDENTIALPROVIDER_WINDOWSINTEGRATEDAUTHENTICATION_ENABLED";
+        public const string DeviceFlowAuthenticationEnvVar = "NUGET_CREDENTIALPROVIDER_DEVICEFLOWAUTHENTICATION_ENABLED";
         public const string ForceCanShowDialogEnvVar = "NUGET_CREDENTIALPROVIDER_FORCE_CANSHOWDIALOG_TO";
 
         public const string AuthorityEnvVar = "NUGET_CREDENTIALPROVIDER_ADAL_AUTHORITY";
@@ -100,6 +101,11 @@ namespace NuGetCredentialProvider.Util
         public static bool WindowsIntegratedAuthenticationEnabled()
         {
             return GetEnabledFromEnvironment(WindowsIntegratedAuthenticationEnvVar);
+        }
+
+        public static bool DeviceFlowAuthenticationEnabled()
+        {
+            return GetEnabledFromEnvironment(DeviceFlowAuthenticationEnvVar);
         }
 
         public static TimeSpan? GetSessionTimeFromEnvironment(ILogger logger)


### PR DESCRIPTION
Implementation is similar to one used for turning off Windows Integrated Auth.