### PR TITLE
fix(credentials): fix credentials for feeds with space in url

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>0.1.24</CredentialProviderVersion>
+    <CredentialProviderVersion>0.1.25</CredentialProviderVersion>
   </PropertyGroup>
 </Project>

--- a/Build.props
+++ b/Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>0.1.25</CredentialProviderVersion>
+    <CredentialProviderVersion>0.1.26</CredentialProviderVersion>
   </PropertyGroup>
 </Project>

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProviderTests.cs
@@ -142,5 +142,22 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.VstsBuildTaskSe
             Assert.AreEqual("testUser", result.Username);
             Assert.AreEqual("testToken", result.Password);
         }
+
+
+        [TestMethod]
+        public async Task HandleRequestAsync_MatchesEndpointURLWithSpaces()
+        {
+            Uri sourceUri = new Uri(@"http://example.pkgs.vsts.me/My Collection/_packaging/TestFeed/nuget/v3/index.json");
+
+            string feedEndPointJson = "{\"endpointCredentials\":[{\"endpoint\":\"http://example.pkgs.vsts.me/My Collection/_packaging/TestFeed/nuget/v3/index.json\", \"username\": \"testUser\", \"password\":\"testToken\"}]}";
+            string feedEndPointJsonEnvVar = EnvUtil.BuildTaskExternalEndpoints;
+
+            Environment.SetEnvironmentVariable(feedEndPointJsonEnvVar, feedEndPointJson);
+
+            var result = await vstsCredentialProvider.HandleRequestAsync(new GetAuthenticationCredentialsRequest(sourceUri, false, false, false), CancellationToken.None);
+            Assert.AreEqual(MessageResponseCode.Success, result.ResponseCode);
+            Assert.AreEqual("testUser", result.Username);
+            Assert.AreEqual("testToken", result.Password);
+        }
     }
 }

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -129,9 +130,16 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                         credentials.Username = "VssSessionToken";
                     }
 
-                    if (credsResult.ContainsKey(credentials.Endpoint) == false)
+                    var urlEncodedEndpoint = WebUtility.UrlEncode(credentials.Endpoint);
+                    if (urlEncodedEndpoint == null)
                     {
-                        credsResult.Add(credentials.Endpoint, credentials);
+                        Verbose(Resources.EndpointParseFailure);
+                        break;
+                    }
+                    
+                    if (credsResult.ContainsKey(urlEncodedEndpoint) == false)
+                    {
+                        credsResult.Add(urlEncodedEndpoint, credentials);
                     }
                 }
 

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
@@ -130,14 +129,14 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                         credentials.Username = "VssSessionToken";
                     }
 
-                    var urlEncodedEndpoint = WebUtility.UrlEncode(credentials.Endpoint);
-                    if (urlEncodedEndpoint == null)
+                    if (!Uri.TryCreate(credentials.Endpoint, UriKind.Absolute, out var endpointUri))
                     {
                         Verbose(Resources.EndpointParseFailure);
                         break;
                     }
-                    
-                    if (credsResult.ContainsKey(urlEncodedEndpoint) == false)
+
+                    var urlEncodedEndpoint = endpointUri.AbsoluteUri;
+                    if (!credsResult.ContainsKey(urlEncodedEndpoint))
                     {
                         credsResult.Add(urlEncodedEndpoint, credentials);
                     }


### PR DESCRIPTION
fix issue with with missing credentials in case feed url contained spaces

fix #210