### PR TITLE
Update README with additional mono msbuild notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,10 @@ Using the above is recommended, but as per [NuGet's plugin discovery rules](http
 #### Automatic bash script
 
 [Linux or Mac helper script](helpers/installcredprovider.sh)
-- e.g. `sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"`
+
+Examples:
+- `wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash`
+- `sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"`
 
 > Note: this script only installs the netcore version of the plugin. If you need to have it working with mono msbuild, you will need to download the version with both netcore and netfx binaries following the steps in [Manual installation on Linux and Mac](#installation-on-linux-and-mac)
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,9 @@ Using the above is recommended, but as per [NuGet's plugin discovery rules](http
 #### Automatic bash script
 
 [Linux or Mac helper script](helpers/installcredprovider.sh)
-- e.g. `wget -qO- https://aka.ms/install-artifacts-credprovider.sh | bash`
+- e.g. `sh -c "$(curl -fsSL https://aka.ms/install-artifacts-credprovider.sh)"`
+
+> Note: this script only installs the netcore version of the plugin. If you need to have it working with mono msbuild, you will need to download the version with both netcore and netfx binaries following the steps in [Manual installation on Linux and Mac](#installation-on-linux-and-mac)
 
 #### Manual installation on Linux and Mac
 


### PR DESCRIPTION
Updated README with some notes about what to do for mono msbuild, as the installcredprovider.sh script only installs the netcore plugin on unix based environments.

Also updated the example on how to download and run. `wget` is not present on macOS per default, so showing an example using `curl` instead.

Fixes #221 partially. You might consider changing the script to _also_ install the netfx plugin.