### PR TITLE
Update dependencies to enable MSAL UI auth flow

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>0.1.26</CredentialProviderVersion>
+    <CredentialProviderVersion>0.1.27</CredentialProviderVersion>
   </PropertyGroup>
 </Project>

--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Build.props))\Build.props" />
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -32,12 +32,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.11.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.8.0-preview" />
-    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.3" />
-    <PackageReference Include="NuGet.Protocol" Version="5.6.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.32.1" />
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.5" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
+    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All"/>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(SignType)' != '' ">


### PR DESCRIPTION
MSAL UI auth flow is required for some users with additional MFA requirements imposed by their AAD admin. For some reason device code flow was not producing correct output (and device flow is also not great UX).

For users who require MSAL UI auth flow, be sure to enable MSAL via the NUGET_CREDENTIALPROVIDER_MSAL_ENABLED environment variable.

It's possible that with this update MSAL should also be enabled by default for the netcore version? But I'd leave that up to the maintainers.