### PR TITLE
Removing System.Security.Cryptography.ProtectedData.dll 

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swr
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swr
@@ -92,7 +92,6 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins\Credenti
   file source=$(PluginBinPath)\System.Security.Cryptography.Csp.dll
   file source=$(PluginBinPath)\System.Security.Cryptography.Encoding.dll
   file source=$(PluginBinPath)\System.Security.Cryptography.Primitives.dll
-  file source=$(PluginBinPath)\System.Security.Cryptography.ProtectedData.dll
   file source=$(PluginBinPath)\System.Security.Cryptography.X509Certificates.dll
   file source=$(PluginBinPath)\System.Security.Principal.dll
   file source=$(PluginBinPath)\System.Security.SecureString.dll


### PR DESCRIPTION
Since update to v[ersion 0.1.27 where dependencies were updated](https://github.com/microsoft/artifacts-credprovider/pull/260/files), apparently System.Security.Cryptography.ProtectedData was removed as a dependency as the assembly no longer installs when building CredentialProvider.Microsoft, so I'm also removing it from VSIX files so the VSIX can build successfully.