### PR TITLE
Upgraded target frameworks to net5;net461 to fix MacOS bug

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5;net461</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <RootNamespace>NuGetCredentialProvider</RootNamespace>
-    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
+    <TargetFrameworks>net5;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>helpericons.ico</ApplicationIcon>
     <Version>$(CredentialProviderVersion)</Version>


### PR DESCRIPTION
On MacOS Big Sur 11.6 when using the plugin you end up with an error:
```
Failed to initialize CoreCLR, HRESULT: 0x80004005
/usr/local/share/dotnet/sdk/6.0.100-rc.2.21505.57/NuGet.targets(130,5): error : Problem starting the plugin '/Users/.../.nuget/plugins/netcore/CredentialProvider.Microsoft/CredentialProvider.Microsoft.dll'. Plugin 'CredentialProvider.Microsoft' failed within 0.245 seconds with exit code 137. [/Users/...../Source/....../src/.....sln]
```
<img width="1168" alt="Xnip2021-10-17_14-09-32" src="https://user-images.githubusercontent.com/2484265/137625042-3b88406a-ac89-41f8-81ea-28049398d5f2.png">



Meanwhile the following SDKs and runtimes are installed on my computer:
```
% dotnet --list-sdks
2.1.805 [/usr/local/share/dotnet/sdk]
3.0.101 [/usr/local/share/dotnet/sdk]
3.1.101 [/usr/local/share/dotnet/sdk]
3.1.200 [/usr/local/share/dotnet/sdk]
3.1.302 [/usr/local/share/dotnet/sdk]
3.1.413 [/usr/local/share/dotnet/sdk]
3.1.414 [/usr/local/share/dotnet/sdk]
5.0.103 [/usr/local/share/dotnet/sdk]
5.0.203 [/usr/local/share/dotnet/sdk]
5.0.302 [/usr/local/share/dotnet/sdk]
5.0.401 [/usr/local/share/dotnet/sdk]
5.0.402 [/usr/local/share/dotnet/sdk]
6.0.100-rc.1.21463.6 [/usr/local/share/dotnet/sdk]
6.0.100-rc.2.21505.57 [/usr/local/share/dotnet/sdk]
```

```
% dotnet --list-runtimes
Microsoft.AspNetCore.App 3.0.1 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.1.19 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 3.1.20 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 5.0.10 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 5.0.11 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 6.0.0-rc.1.21452.15 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.AspNetCore.App 6.0.0-rc.2.21480.10 [/usr/local/share/dotnet/shared/Microsoft.AspNetCore.App]
Microsoft.NETCore.App 2.1.23 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 3.0.1 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 3.1.19 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 3.1.20 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 5.0.10 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 5.0.11 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
Microsoft.NETCore.App 6.0.0-rc.2.21480.5 [/usr/local/share/dotnet/shared/Microsoft.NETCore.App]
```

After upgrading the target framework and building the plugin from sources I was able to fix the error.