### PR TITLE
Update installcredprovider.ps1 to support Powershell Core in NanoServer container

### DIFF
--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -22,7 +22,12 @@ if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -no
     [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
 }
 
-$profilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
+if ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile) -ne '') {
+    $profilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
+} else {
+    $profilePath = $env:UserProfile
+}
+
 $tempPath = [System.IO.Path]::GetTempPath()
 
 $pluginLocation = [System.IO.Path]::Combine($profilePath, ".nuget", "plugins");

--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -22,8 +22,9 @@ if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -no
     [Net.ServicePointManager]::SecurityProtocol += [Net.SecurityProtocolType]::Tls12
 }
 
-if ([System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile) -ne '') {
-    $profilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile)
+$userProfilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile);
+if ($userProfilePath -ne '') {
+    $profilePath = $userProfilePath
 } else {
     $profilePath = $env:UserProfile
 }


### PR DESCRIPTION
Adds support for Powershell Core when running in a Docker NanoServer container. 

The GetFolderPath function does not resolve correctly in this environment, however `$env:UserProfile` does. So this PR adds a fallback if the `[System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile` function returns an empty string, to use the `$env:UserProfile` environment variable instead.

![image](https://user-images.githubusercontent.com/24935514/140911233-80f42d00-f7a4-49a3-a3cb-091b257e9d68.png)
