### PR TITLE
Update Nuget.Protocol

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -35,7 +35,7 @@
     <PackageReference Include="Microsoft.Identity.Client" Version="4.32.1" />
     <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.18.5" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
-    <PackageReference Include="NuGet.Protocol" Version="5.10.0" />
+    <PackageReference Include="NuGet.Protocol" Version="6.0.0" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.json" Version="13.0.1" />


### PR DESCRIPTION
A fix for [this issue](https://github.com/NuGet/Home/issues/11169) has been released. See [NuGet 6 release notes](https://docs.microsoft.com/en-us/nuget/release-notes/nuget-6.0). Updating credprovider to latest NuGet.Protocol version. Should hopefully fix issue #250 