### PR TITLE
Vsts doesn't handle pkgs.dev.azure.com feeds hence cache is not working

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/VstsCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/VstsCredentialProviderTests.cs
@@ -72,6 +72,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
                 @"https://example.pkgs.codeapp.ms/_packaging/TestFeed/nuget/v3/index.json",
                 @"https://example.pkgs.visualstudio.com/_packaging/TestFeed/nuget/v3/index.json",
                 @"https://example.pkgs.dev.azure.com/_packaging/TestFeed/nuget/v3/index.json",
+                @"https://pkgs.dev.azure.com/OrganisationNameExample/_packaging/TestFeed/nuget/v3/index.json"
             };
 
             foreach (var source in sources)

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -55,7 +55,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                  ".pkgs.codedev.ms", // DevFabric
                  ".pkgs.codeapp.ms", // AppFabric
                  ".pkgs.visualstudio.com", // Prod
-                 ".pkgs.dev.azure.com" // Prod
+                 "pkgs.dev.azure.com" // Prod
              });
 
             bool isValidHost = validHosts.Any(host => uri.Host.EndsWith(host, StringComparison.OrdinalIgnoreCase));


### PR DESCRIPTION
See https://github.com/dotnet/templating/issues/4278 for more info