### PR TITLE
changed install from cli example

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Dotnet needs the `netcore` version to be installed. NuGet and MSBuild need the `
 
 [PowerShell helper script](helpers/installcredprovider.ps1)
 - To install netcore, run `installcredprovider.ps1`
-  - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }"`
+  - e.g. `powershell wget https://aka.ms/install-artifacts-credprovider.ps1 -OutFile install-artifacts-credprovider.ps1 && powershell ./install-artifacts-credprovider.ps1`
 - To install both netfx and netcore, run `installcredprovider.ps1 -AddNetfx`. The netfx version is needed for nuget.exe.
   - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
 

--- a/README.md
+++ b/README.md
@@ -37,10 +37,12 @@ Dotnet needs the `netcore` version to be installed. NuGet and MSBuild need the `
 #### Automatic PowerShell script
 
 [PowerShell helper script](helpers/installcredprovider.ps1)
+- Use powershell.exe to perform the following steps
 - To install netcore, run `installcredprovider.ps1`
-  - e.g. `powershell wget https://aka.ms/install-artifacts-credprovider.ps1 -OutFile install-artifacts-credprovider.ps1 && powershell ./install-artifacts-credprovider.ps1`
+  - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }"`
 - To install both netfx and netcore, run `installcredprovider.ps1 -AddNetfx`. The netfx version is needed for nuget.exe.
   - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
+
 
 #### Manual installation on Windows
 


### PR DESCRIPTION
**Update**
This PR is a slight change to the instructions to make it clear that the powershell script example can only be run from powershell.exe.  I've been running powershell scripts and commands from cmd.exe for many years and this actually tripped me up.  Thank you for your time.

**Previous comment:**
Description:
Changed the cli install example to use wget to fetch and then run the script.  This command downloaded and ran the installer without issue.  Also included powershell in the example because not every dev would know to prefix that without being told to do so.  Typically a command presented as a code snippet should be complete and not expect the user to make changes to it (defeating the purpose of a copy/paste command).

Reason for change:
Received an "Access Denied" error when attempting to use the install example from cli.  Also tried it as an administrator.  Found a Microsoft article explaining that iex shouldn't be used: https://devblogs.microsoft.com/powershell/invoke-expression-considered-harmful/
![image](https://user-images.githubusercontent.com/1475235/153494108-27c6078a-27ea-4721-9057-2cc5491bf094.png)


Please let me know if there are any alterations needed.