### PR TITLE
Allow installation of releases other than latest

### DIFF
--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -6,9 +6,9 @@
 
 REPO="Microsoft/artifacts-credprovider"
 FILE="Microsoft.NuGet.CredentialProvider.tar.gz"
-VERSION="latest"
+: ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION="latest"}
 # URL pattern documented at https://help.github.com/en/articles/linking-to-releases as of 2019-03-29
-URI="https://github.com/$REPO/releases/$VERSION/download/$FILE"
+URI="https://github.com/$REPO/releases/${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}/download/$FILE"
 NUGET_PLUGIN_DIR="$HOME/.nuget/plugins"
 
 # Ensure plugin directory exists


### PR DESCRIPTION
The current PowerShell installation helper allows users to install a specific version of the credential provider, but the same capability is not extended to the Bash version.

This change allows users to set an environment variable to specify a version other than `latest`. I changed the name of the `$VERSION` environment variable to decrease the likelihood of a conflict with the user's environment.

### Example usage:

#### Installing `latest`
```bash
curl -fsSL https://aka.ms/install-artifacts-credprovider.sh
```

#### Installing `0.1.25`
```bash
export AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION='0.1.25'
curl -fsSL https://aka.ms/install-artifacts-credprovider.sh
```