### PR TITLE
Users/embetten/downloadurlfix

### DIFF
--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # If AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION is set, install the version specified, otherwise install latest
-if [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} != "latest" ]]; then
+if [[ ! -z ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} ] || [ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} != "latest" ]]; then
   # browser_download_url from https://api.github.com/repos/Microsoft/artifacts-credprovider/releases/latest 
   URI="https://github.com/$REPO/releases/download/${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}/$FILE"
 else

--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # If AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION is set, install the version specified, otherwise install latest
-if [[ ! -z ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} ]]; then
+if [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} != "latest" ]]; then
   # browser_download_url from https://api.github.com/repos/Microsoft/artifacts-credprovider/releases/latest 
   URI="https://github.com/$REPO/releases/download/${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}/$FILE"
 else


### PR DESCRIPTION
Fix for issue #303. 

Because we set the `${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION` default to latest the previous check was always true and caused the url to be formed incorrectly. 