### PR TITLE
Fix credential provider release build and resolve build warnings

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -8,7 +8,7 @@ trigger:
 - master
 
 variables:
-  BuildConfiguration: 'Debug'
+  BuildConfiguration: 'Release'
   PushNupkg: 'True'
   TeamName: 'Package Experience'
 

--- a/.vsts-release.yml
+++ b/.vsts-release.yml
@@ -23,3 +23,4 @@ steps:
 - template: build/build.yml
   parameters:
     sign: true
+    nuspecProperties: 'Configuration=Release'

--- a/Build.props
+++ b/Build.props
@@ -3,5 +3,6 @@
   <PropertyGroup>
     <CredentialProviderVersion>1.0.0</CredentialProviderVersion>
     <TargetFrameworks>netcoreapp3.1;net461;net6.0</TargetFrameworks>
+    <NoSwixBuildPlugin>true</NoSwixBuildPlugin>
   </PropertyGroup>
 </Project>

--- a/Build.props
+++ b/Build.props
@@ -3,6 +3,5 @@
   <PropertyGroup>
     <CredentialProviderVersion>1.0.0</CredentialProviderVersion>
     <TargetFrameworks>netcoreapp3.1;net461;net6.0</TargetFrameworks>
-    <NoSwixBuildPlugin>true</NoSwixBuildPlugin>
   </PropertyGroup>
 </Project>

--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swixproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swixproj
@@ -22,14 +22,6 @@
     <PluginBinPath>..\CredentialProvider.Microsoft\bin\$(Configuration)\net461\</PluginBinPath>
   </PropertyGroup>
 
-  <!-- Needed for the MicroBuild signing plugin -->
-  <ItemGroup>
-    <SigningTarget Include="$(OutDir)$(OutputName)"/>
-    <FilesToSign Include="@(SigningTarget)">
-      <Authenticode>VsixSHA2</Authenticode>
-    </FilesToSign>
-  </ItemGroup>
-
   <ItemGroup>
     <Package Include="Microsoft.CredentialProvider.swr" />
   </ItemGroup>

--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
@@ -6,7 +6,7 @@
     <!-- Define properties that drive the manifest creation here. -->
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.props" />
 
   <PropertyGroup>

--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
@@ -6,6 +6,7 @@
     <!-- Define properties that drive the manifest creation here. -->
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
@@ -46,7 +46,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 var fileName = Path.GetFileName(cacheLocation);
                 var directory = Path.GetDirectoryName(cacheLocation);
 
-                var builder = new StorageCreationPropertiesBuilder(fileName, directory, this.clientId);
+                var builder = new StorageCreationPropertiesBuilder(fileName, directory).WithCacheChangedEvent(this.clientId);
                 StorageCreationProperties creationProps = builder.Build();
                 helper = await MsalCacheHelper.CreateAsync(creationProps);
             }

--- a/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
+++ b/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
@@ -23,6 +23,7 @@ namespace NuGetCredentialProvider.Util
         {
             this.cacheFilePath = cacheFilePath;
             this.logger = logger;
+            this.cancellationToken = cancellationToken;
             this.mutexName = @"Global\" + cacheFilePath.Replace(Path.DirectorySeparatorChar, '_');
         }
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -14,7 +14,10 @@ steps:
   inputs:
     packageType: sdk
     version: 6.x
-    
+
+- task: NuGetToolInstaller@1
+  displayName: NuGet Install
+
 - task: NuGetAuthenticate@1
   displayName: NuGet Authenticate
 
@@ -30,16 +33,10 @@ steps:
     inputs:
       feedSource: 'https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-  - task: NuGetCommand@2
+  - script: nuget restore CredentialProvider.Microsoft.VSIX/packages.config -OutputDirectory packages
     displayName: NuGet restore
-    inputs:
-      command: restore
-      restoreSolution: CredentialProvider.Microsoft.VSIX/packages.config
-      feedsToUse: config
-      nugetConfigPath: CredentialProvider.Microsoft.VSIX/nuget.config
-      restoreDirectory: packages
 
-- script: dotnet restore 
+- script: dotnet restore
   displayName: dotnet restore NuGet.config CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
 
 - task: MSBuild@1

--- a/build/build.yml
+++ b/build/build.yml
@@ -30,8 +30,11 @@ steps:
     inputs:
       feedSource: 'https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-  - script: nuget restore CredentialProvider.Microsoft.VSIX/packages.config -OutputDirectory packages
+  - task: NuGetCommand@2
     displayName: NuGet restore
+    inputs:
+      restoreSolution: CredentialProvider.Microsoft.VSIX/packages.config
+      restoreDirectory: packages
 
 - script: dotnet restore 
   displayName: dotnet restore NuGet.config CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj

--- a/build/build.yml
+++ b/build/build.yml
@@ -69,6 +69,7 @@ steps:
     inputs:
       DropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
       DropServiceUri: https://mseng.artifacts.visualstudio.com
+      AccessToken: $(System.AccessToken)
 
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj --logger trx --results-directory $(Agent.TempDirectory)

--- a/build/build.yml
+++ b/build/build.yml
@@ -199,7 +199,7 @@ steps:
   inputs:
     SymbolsFolder: '$(Build.ArtifactStagingDirectory)\symbols'
     SearchPattern:  '**\*.pdb'
-    IndexSources: true
+    IndexSources: false
     PublishSymbols: ${{ eq(parameters.sign, 'true') }}
     SymbolServerType: TeamServices
     SymbolsProduct: 'artifacts-credprovider'

--- a/build/build.yml
+++ b/build/build.yml
@@ -33,6 +33,8 @@ steps:
   - task: NuGetCommand@2
     displayName: NuGet restore
     inputs:
+      feedsToUse: config
+      nugetConfigPath: CredentialProvider.Microsoft.VSIX/nuget.config
       restoreSolution: CredentialProvider.Microsoft.VSIX/packages.config
       restoreDirectory: packages
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -69,6 +69,7 @@ steps:
     inputs:
       DropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
       DropServiceUri: https://mseng.artifacts.visualstudio.com
+      DropRetentionDays: 365
       AccessToken: $(System.AccessToken)
 
 - ${{ if ne(parameters.sign, 'true') }}:

--- a/build/build.yml
+++ b/build/build.yml
@@ -33,8 +33,9 @@ steps:
     inputs:
       feedSource: 'https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json'
 
-  - script: nuget restore CredentialProvider.Microsoft.VSIX/packages.config -OutputDirectory packages
+  - script: nuget restore packages.config -PackagesDirectory packages
     displayName: NuGet restore
+    workingDirectory: CredentialProvider.Microsoft.VSIX
 
 - script: dotnet restore
   displayName: dotnet restore NuGet.config CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj

--- a/build/build.yml
+++ b/build/build.yml
@@ -196,17 +196,19 @@ steps:
       **\CredentialProvider.Microsoft.pdb
     TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols'
 
-- task: PublishSymbols@2
-  inputs:
-    SymbolsFolder: '$(Build.ArtifactStagingDirectory)\symbols'
-    SearchPattern:  '**\*.pdb'
-    IndexSources: false
-    PublishSymbols: ${{ eq(parameters.sign, 'true') }}
-    SymbolServerType: TeamServices
-    SymbolsProduct: 'artifacts-credprovider'
-  env:
-    ArtifactServices.Symbol.AccountName: 'microsoft'
-    ArtifactServices.Symbol.UseAAD: 'true'
+- ${{ if eq(parameters.sign, 'true') }}:
+  - task: PublishSymbols@2
+    displayName: Publish Symbols
+    inputs:
+      SymbolsFolder: '$(Build.ArtifactStagingDirectory)\symbols'
+      SearchPattern:  '**\*.pdb'
+      IndexSources: false
+      PublishSymbols: true
+      SymbolServerType: TeamServices
+      SymbolsProduct: 'artifacts-credprovider'
+    env:
+      ArtifactServices.Symbol.AccountName: 'microsoft'
+      ArtifactServices.Symbol.UseAAD: 'true'
 
 - task: PublishPipelineArtifact@1
   displayName: 'Upload symbols'

--- a/build/build.yml
+++ b/build/build.yml
@@ -42,12 +42,12 @@ steps:
 - script: dotnet restore 
   displayName: dotnet restore NuGet.config CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
 
-- task: VSBuild@1
+- task: MSBuild@1
   displayName: Build CredentialProvider
   inputs:
     solution: 'CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj'
     configuration: '$(BuildConfiguration)'
-    msbuildArgs: '/t:rebuild'
+    msbuildArguments: '/t:rebuild /p:TreatWarningsAsErrors=true'
 
 - ${{ if eq(parameters.sign, 'true') }}:
   - task: MSBuild@1
@@ -55,14 +55,14 @@ steps:
     inputs:
       solution: 'CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swixproj'
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
+      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\ /p:TreatWarningsAsErrors=true'
 
   - task: MSBuild@1
     displayName: Build vsmanproj
     inputs:
       solution: 'CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj'
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
+      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\ /p:TreatWarningsAsErrors=true'
 
   - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@2
     displayName: Upload VSTS Drop

--- a/build/build.yml
+++ b/build/build.yml
@@ -198,7 +198,7 @@ steps:
 
 - ${{ if eq(parameters.sign, 'true') }}:
   - task: PublishSymbols@2
-    displayName: Publish Symbols
+    displayName: Publish symbols
     inputs:
       SymbolsFolder: '$(Build.ArtifactStagingDirectory)\symbols'
       SearchPattern:  '**\*.pdb'

--- a/build/build.yml
+++ b/build/build.yml
@@ -68,6 +68,7 @@ steps:
     displayName: Upload VSTS Drop
     inputs:
       DropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
+      DropServiceUri: https://mseng.artifacts.visualstudio.com
 
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj --logger trx --results-directory $(Agent.TempDirectory)

--- a/build/build.yml
+++ b/build/build.yml
@@ -68,7 +68,6 @@ steps:
     displayName: Upload VSTS Drop
     inputs:
       DropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
-      AccessToken: $(DevDivDropManageAccessToken)
 
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj --logger trx --results-directory $(Agent.TempDirectory)

--- a/build/build.yml
+++ b/build/build.yml
@@ -33,9 +33,10 @@ steps:
   - task: NuGetCommand@2
     displayName: NuGet restore
     inputs:
+      command: restore
+      restoreSolution: CredentialProvider.Microsoft.VSIX/packages.config
       feedsToUse: config
       nugetConfigPath: CredentialProvider.Microsoft.VSIX/nuget.config
-      restoreSolution: CredentialProvider.Microsoft.VSIX/packages.config
       restoreDirectory: packages
 
 - script: dotnet restore 


### PR DESCRIPTION
The release build for ingestion to Visual Studio was broken by service connection remediation so needed to be recreated. Some recent changes in the build templates are now no longer compatible with the build machines running release builds. Also fixing some miscellaneous build and release warnings that have snuck in.