### PR TITLE
Fix CI build by specifying configuration

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -217,7 +217,7 @@ steps:
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")' 
   displayName: Clear SignType
 
-- script: dotnet pack CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
+- script: dotnet pack CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet pack
 
 - script: dotnet nuget push $(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\*.nupkg --source artifacts-credprovider --api-key unimportantValue


### PR DESCRIPTION
Testing release builds didn't hit this issue because the configuration was specified in nuspecProperties. Explicitly setting the configuration as part of the command.