### PR TITLE
Enable MSAL by default and use new application for broker

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
@@ -48,6 +48,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -58,6 +59,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeadersAndPpe_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -68,6 +70,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeadersAndPpeAndPpeOverride_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var ppeUris = new[]
             {
                 new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json"),
@@ -80,6 +83,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
             foreach (var ppeUri in ppeUris)
             {
                 var authorityUri = await authUtil.GetAadAuthorityUriAsync(ppeUri, cancellationToken);
+
                 authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/common"));
             }
         }
@@ -104,7 +108,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
             MockAadAuthorityHeaders(testAuthority);
 
-            Environment.SetEnvironmentVariable(EnvUtil.AuthorityEnvVar, overrideAuthority.ToString());
+            Environment.SetEnvironmentVariable(EnvUtil.MsalAuthorityEnvVar, overrideAuthority.ToString());
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
 
             authorityUri.Should().Be(overrideAuthority);
@@ -200,8 +204,6 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task MsalGetAadAuthorityUri_WithoutAuthenticateHeadersAndPpeAndPpeOverride_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
-
             var ppeUris = new[]
             {
                 new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json"),
@@ -220,9 +222,8 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         }
 
         [TestMethod]
-        public async Task MsaltAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
+        public async Task MsalAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -232,7 +233,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
 
         [TestMethod]
-        public async Task MsaltAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthorityFalseEnvVar()
+        public async Task MsalAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthorityFalseEnvVar()
         {
             Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
@@ -245,7 +246,6 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task MsalGetAadAuthorityUri_WithoutAuthenticateHeadersAndPpe_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
             var requestUri = new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);

--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
@@ -217,7 +217,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
             foreach (var ppeUri in ppeUris)
             {
                 var authorityUri = await authUtil.GetAadAuthorityUriAsync(ppeUri, cancellationToken);
-                authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a"));
+                authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/organizations"));
             }
         }
 
@@ -228,7 +228,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
 
-            authorityUri.Should().Be(new Uri("https://login.microsoftonline.com/f8cdef31-a31e-4b4a-93e4-5f571e91255a"));
+            authorityUri.Should().Be(organizationsAuthority);
         }
 
 
@@ -250,7 +250,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
 
-            authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/f8cdef31-a31e-4b4a-93e4-5f571e91255a"));
+            authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/organizations"));
         }
 
         private void MockResponseHeaders(string key, string value)

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/IAuthUtil.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/IAuthUtil.cs
@@ -33,10 +33,11 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
     {
         public const string VssResourceTenant = "X-VSS-ResourceTenant";
         public const string VssAuthorizationEndpoint = "X-VSS-AuthorizationEndpoint";
+        public const string VssE2EID = "X-VSS-E2EID";
+        private const string OrganizationsTenant = "organizations";
         private const string CommonTenant = "common";
         public static readonly Guid FirstPartyTenant = Guid.Parse("f8cdef31-a31e-4b4a-93e4-5f571e91255a");
         public static readonly Guid MsaAccountTenant = Guid.Parse("9188040d-6c67-4c5b-b112-36a304b66dad");
-        public const string VssE2EID = "X-VSS-E2EID";
 
         private readonly ILogger logger;
 
@@ -84,7 +85,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
             // WAM gets confused about the Common tenant, so we'll just assume that if there isn't
             // a tenant GUID provided, that it's a consumer tenant.
-            var tenant = EnvUtil.MsalEnabled() ? FirstPartyTenant.ToString() : CommonTenant;
+            var tenant = EnvUtil.MsalEnabled() ? OrganizationsTenant : CommonTenant;
 
             return new Uri($"{aadBase}/{tenant}");
         }

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
@@ -158,6 +158,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                     this.Logger.Verbose($"Attempting to use identity `{canonicalName}`");
 
                     var result = await publicClient.AcquireTokenSilent(new string[] { resource }, account)
+                        .WithAccountTenantId(account)
                         .ExecuteAsync(cancellationToken);
 
                     return new MsalToken(result);
@@ -255,10 +256,6 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 {
                     this.Logger.Verbose($"MSAL using WithBrokerPreview");
 
-                    // The application being used doesn't support MSA passthrough, so disable if using an MSA.
-                    // Still want to enable for non-MSA as this setting affects the broker UI for non-MSA accounts.
-                    bool msaPassthrough = !this.authority.AbsolutePath.Contains(AuthUtil.FirstPartyTenant.ToString());
-
                     publicClientBuilder
                         .WithBrokerPreview()
                         .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow())
@@ -266,7 +263,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                         {
                             HeaderText = "Azure DevOps Artifacts",
                             ListWindowsWorkAndSchoolAccounts = true,
-                            MsaPassthrough = msaPassthrough
+                            MsaPassthrough = true
                         });
                 }
                 else

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProviderFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProviderFactory.cs
@@ -10,11 +10,12 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
     internal class MsalTokenProviderFactory : IMsalTokenProviderFactory
     {
         private const string Resource = "499b84ac-1321-427f-aa17-267ca6975798/.default";
-        private const string ClientId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
+        private const string ClientId = "d5a56ea4-7369-46b8-a538-c370805301bf";
+        private const string LegacyClientId = "872cd9fa-d31f-45e0-9eab-6e460a02d1f1";
 
         public IMsalTokenProvider Get(Uri authority, bool brokerEnabled, ILogger logger)
         {
-            return new MsalTokenProvider(authority, Resource, ClientId, brokerEnabled, logger);
+            return new MsalTokenProvider(authority, Resource, brokerEnabled ? ClientId : LegacyClientId, brokerEnabled, logger);
         }
     }
 }

--- a/CredentialProvider.Microsoft/Resources.Designer.cs
+++ b/CredentialProvider.Microsoft/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace NuGetCredentialProvider {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -839,7 +839,7 @@ namespace NuGetCredentialProvider {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Found SessionToken for {0}.
+        ///   Looks up a localized string similar to Created SessionToken for {0}.
         /// </summary>
         internal static string VSTSSessionTokenCreated {
             get {

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -260,7 +260,7 @@
     <value>Could not obtain credentials for {0}</value>
   </data>
   <data name="VSTSSessionTokenCreated" xml:space="preserve">
-    <value>Found SessionToken for {0}</value>
+    <value>Created SessionToken for {0}</value>
   </data>
   <data name="VSTSSessionTokenValidity" xml:space="preserve">
     <value>Requesting a {0} token valid for duration {1}, valid until {2} UTC. Note that the generated token may have different validity than requested.</value>

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -110,7 +110,7 @@ namespace NuGetCredentialProvider.Util
 
         internal static bool MsalEnabled()
         {
-            return GetEnabledFromEnvironment(MsalEnabledEnvVar, defaultValue: false);
+            return GetEnabledFromEnvironment(MsalEnabledEnvVar, defaultValue: true);
         }
 
         public static bool MsalFileCacheEnabled()


### PR DESCRIPTION
Turning on MSAL by default, with the goal of deprecating ADAL usage. ADAL can be turned back on by:
```
set NUGET_CREDENTIALPROVIDER_MSAL_ENABLED=false
```

Also using the new Azure Artifacts application that is enabled for both AAD + MSA and MSA Passthrough and enabling when the broker preview is enabled.