### PR TITLE
Install scripts default to .NET 6.0 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,11 +21,11 @@ Install [Visual Studio version 15.9-preview1 or later](https://visualstudio.micr
 
 ### NuGet
 
-[NuGet(.exe)](https://www.nuget.org/downloads) on the command line version `4.8.0.5385` or later is required. The recommended NuGet version is `5.5.x` or later as it has some important bug fixes related to cancellations and timeouts. 
+[NuGet(.exe)](https://www.nuget.org/downloads) on the command line version `4.8.0.5385` or later is required. The recommended NuGet version is `5.5.x` or later as it has some important bug fixes related to cancellations and timeouts.
 
 ### dotnet
 
-The default installation requires [dotnet SDK](https://www.microsoft.com/net/download) version `3.1.x`. The recommended dotnet version is `3.1.200` or later as it has some important bug fixes related to cancellations and timeouts. 
+The default installation requires [dotnet SDK](https://www.microsoft.com/net/download) version `6.0.x`.
 
 ## Setup
 
@@ -84,7 +84,7 @@ Because the Credential Provider is a NuGet plugin, it is most commonly used indi
 
 ### dotnet
 
-The first time you perform an operation that requires authentication using `dotnet`, you must either use the `--interactive` flag to allow `dotnet` to prompt you for credentials, or provide them via an environment variable. 
+The first time you perform an operation that requires authentication using `dotnet`, you must either use the `--interactive` flag to allow `dotnet` to prompt you for credentials, or provide them via an environment variable.
 
 If you're running interactively navigate to your project directory and run:
 
@@ -114,7 +114,7 @@ msbuild /t:restore /p:nugetInteractive=true
 
 Once you've successfully acquired a token, you can run authenticated commands without the `/p:nugetInteractive=true` switch.
 
-### Unattended build agents 
+### Unattended build agents
 
 #### Azure DevOps Pipelines
 Use the [NuGet Authenticate](https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/package/nuget-authenticate?view=azure-devops) task before running NuGet, dotnet or MSBuild commands that need authentication.
@@ -126,9 +126,9 @@ If you're running the command as part of an automated build on an unattended bui
 [Managing NuGet credentials in Docker scenarios](https://github.com/dotnet/dotnet-docker/blob/master/documentation/scenarios/nuget-credentials.md#using-the-azure-artifact-credential-provider)
 
 ### Azure DevOps Server
-The Azure Artifacts Credential Provider may not be necessary for an on-premises Azure DevOps Server on Windows. If the credential provider is needed, it cannot acquire credentials interactively, therefore, the VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable must be used as an alternative. Supply a [Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment-variables). 
+The Azure Artifacts Credential Provider may not be necessary for an on-premises Azure DevOps Server on Windows. If the credential provider is needed, it cannot acquire credentials interactively, therefore, the VSS_NUGET_EXTERNAL_FEED_ENDPOINTS environment variable must be used as an alternative. Supply a [Personal Access Token](https://docs.microsoft.com/en-us/azure/devops/organizations/accounts/use-personal-access-tokens-to-authenticate?view=azure-devops) directly using the `VSS_NUGET_EXTERNAL_FEED_ENDPOINTS` [environment variable](#environment-variables).
 
-From Azure DevOps Server 2020 RC1 forward, the NuGet Authenticate task can be used in Pipelines. 
+From Azure DevOps Server 2020 RC1 forward, the NuGet Authenticate task can be used in Pipelines.
 
 ## Session Token Cache Locations
 
@@ -162,7 +162,7 @@ The windows plugin, delivered in the `netfx` folder of `Microsoft.NuGet.Credenti
 C:\> .\CredentialProvider.Microsoft.exe -h
 Command-line v0.1.17: .\CredentialProvider.Microsoft.exe  -h
 
-The Azure Artifacts credential provider can be used to aquire credentials for Azure Artifacts.
+The Azure Artifacts credential provider can be used to acquire credentials for Azure Artifacts.
 
 Note: The Azure Artifacts Credential Provider is mainly intended for use via integrations with development tools such as .NET Core and nuget.exe.
 While it can be used via this CLI in "stand-alone mode", please pay special attention to certain options such as -IsRetry below.
@@ -287,18 +287,18 @@ NuGet workarounds
 
 ### Troubleshooting
 #### How do I know the cred provider is installed correctly? / I'm still getting username/password prompt after installing
-This means that either nuget/dotnet was unable to find the cred provider from [NuGet's plugin search path](https://github.com/microsoft/artifacts-credprovider#setup), or the cred provider failed to authenticate so the client defaulted to the username/password prompt. Verify the cred provider is correctly installed by checking it exists in the nuget/plugins folder in your user profile (Refer to the [setup docs](https://github.com/microsoft/artifacts-credprovider#setup)). If using nuget.exe and used the [install script](https://github.com/microsoft/artifacts-credprovider#automatic-powershell-script) to install the cred provider, please make sure you ran it with -AddNetfx. 
+This means that either nuget/dotnet was unable to find the cred provider from [NuGet's plugin search path](https://github.com/microsoft/artifacts-credprovider#setup), or the cred provider failed to authenticate so the client defaulted to the username/password prompt. Verify the cred provider is correctly installed by checking it exists in the nuget/plugins folder in your user profile (Refer to the [setup docs](https://github.com/microsoft/artifacts-credprovider#setup)). If using nuget.exe and used the [install script](https://github.com/microsoft/artifacts-credprovider#automatic-powershell-script) to install the cred provider, please make sure you ran it with -AddNetfx.
 
 #### How do I get better error logs from the cred provider?
 Run the nuget.exe/dotnet command with detailed verbosity to see more cred provider logs that may help debugging (`nuget.exe -verbosity detailed`, `dotnet --verbosity detailed`).
 
 #### How do I find out if my issue is a real 401?
-Run the credential provider directly with the following command: `C:\Users\<user>\.nuget\plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe  -I -V Verbose -U "https://pkgs.dev.azure.com/{organization}/{project-if-feed-is-project-scoped}/_packaging/{feed}/nuget/v3/index.json"`. Check you have the right permissions from the [feed permissions](https://docs.microsoft.com/en-us/azure/devops/artifacts/feeds/feed-permissions?view=azure-devops). 
+Run the credential provider directly with the following command: `C:\Users\<user>\.nuget\plugins\netfx\CredentialProvider.Microsoft\CredentialProvider.Microsoft.exe  -I -V Verbose -U "https://pkgs.dev.azure.com/{organization}/{project-if-feed-is-project-scoped}/_packaging/{feed}/nuget/v3/index.json"`. Check you have the right permissions from the [feed permissions](https://docs.microsoft.com/en-us/azure/devops/artifacts/feeds/feed-permissions?view=azure-devops).
 
 In an Azure DevOps Pipeline, verify you have set the right permissions for the pipeline by following the [docs](https://docs.microsoft.com/en-us/azure/devops/artifacts/feeds/feed-permissions?view=azure-devops#package-permissions-in-azure-pipelines).
 
 #### Cred provider used to work but now it asks me to update to .NET Core 3.1.
-Because .NET Core 2 is [out of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle), you should update to .NET Core 3.1 or greater to keep using the latest versions of the credential provider. 
+Because .NET Core 2 is [out of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle), you should update to .NET Core 3.1 or greater to keep using the latest versions of the credential provider.
 
 If you keep using the unsupported .NET Core 2.1 you must use Artifacts Credential Provider version 0.1.28 or lower.
 

--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -3,10 +3,7 @@
 # To install netcore, run installcredprovider.ps1
 # To install netcore and netfx, run installcredprovider.ps1 -AddNetfx
 # To overwrite existing plugin with the latest version, run installcredprovider.ps1 -Force
-# To use a specific version of a credential provider, run installcredprovider.ps1 -Version "0.1.17" or installcredprovider.ps1 -Version "0.1.17" -Force
-# To install Net6 version of the netcore cred provider instead of the default NetCore3.1, run installcredprovider.ps1 - InstallNet6
-# Note that you are not able to install the Net6 version if also using the version flag and installing a version lower than 1.0.0
-# More: https://github.com/Microsoft/artifacts-credprovider/blob/master/README.md
+# To use a specific version of a credential provider, run installcredprovider.ps1 -Version "1.0.1" or installcredprovider.ps1 -Version "1.0.1" -Force
 
 param(
     # whether or not to install netfx folder for nuget
@@ -15,8 +12,8 @@ param(
     [switch]$Force,
     # install the version specified
     [string]$Version,
-    # install Net6 version of the netcore cred provider instead of the default NetCore3.1
-    [switch]$InstallNet6
+    # install Net6 version of the netcore cred provider instead of NetCore3.1
+    [switch]$InstallNet6 = $true
 )
 
 $script:ErrorActionPreference='Stop'
@@ -107,20 +104,20 @@ function InstallZip {
     try {
         Write-Host "Fetching release $releaseUrl"
         $release = Invoke-WebRequest -UseBasicParsing $releaseUrl
-        if (!$release) { 
-            throw ("Unable to make Web Request to $releaseUrl") 
+        if (!$release) {
+            throw ("Unable to make Web Request to $releaseUrl")
         }
         $releaseJson = $release.Content | ConvertFrom-Json
-        if (!$releaseJson) { 
-            throw ("Unable to get content from JSON") 
+        if (!$releaseJson) {
+            throw ("Unable to get content from JSON")
         }
         $zipAsset = $releaseJson.assets | ? { $_.name -eq $zipFile }
-        if (!$zipAsset) { 
-            throw ("Unable to find asset $zipFile from release json object") 
-        }  
+        if (!$zipAsset) {
+            throw ("Unable to find asset $zipFile from release json object")
+        }
         $packageSourceUrl = $zipAsset.browser_download_url
-        if (!$packageSourceUrl) { 
-            throw ("Unable to find download url from asset $zipAsset") 
+        if (!$packageSourceUrl) {
+            throw ("Unable to find download url from asset $zipAsset")
         }
     }
     catch {
@@ -151,7 +148,7 @@ function InstallZip {
     [System.IO.Compression.ZipFile]::ExtractToDirectory($pluginZip, $tempZipLocation)
 }
 
-# Call InstallZip function 
+# Call InstallZip function
 InstallZip
 
 # Remove existing content and copy netfx directories to plugins directory

--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -5,21 +5,18 @@
 
 # Default version to install is the latest version.
 # To install a release other than `latest`, set the `AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION` environment
-# variable to match the TAG NAME of a supported release, e.g. "v0.1.28".
+# variable to match the TAG NAME of a supported release, e.g. "v1.0.1".
 # Releases: https://github.com/microsoft/artifacts-credprovider/releases
-
-# To install the NET6 credential provider instead of the default, NetCore3.1, 
-# set the `USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER` environment variable.
 
 REPO="Microsoft/artifacts-credprovider"
 NUGET_PLUGIN_DIR="$HOME/.nuget/plugins"
 
 # determine whether we install default or Net6
-if [[ ! -z ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} ]]; then
+if [[ -z ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} ]] || [[ ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} != "false" ]]; then
   FILE="Microsoft.Net6.NuGet.CredentialProvider.tar.gz"
 
   # throw if version starts with 0. (net6 not supported)
-  if [[ ! -z ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} ]] && [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} == 0.* ]] || [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} == v0.* ]]; then 
+  if [[ ! -z ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} ]] && [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} == 0.* ]] || [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} == v0.* ]]; then
     echo "ERROR: To install NET6 cred provider using the USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.0.0. or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
     exit 1
   fi
@@ -29,7 +26,7 @@ fi
 
 # If AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION is set, install the version specified, otherwise install latest
 if [[ ! -z ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} ]] && [[ ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} != "latest" ]]; then
-  # browser_download_url from https://api.github.com/repos/Microsoft/artifacts-credprovider/releases/latest 
+  # browser_download_url from https://api.github.com/repos/Microsoft/artifacts-credprovider/releases/latest
   URI="https://github.com/$REPO/releases/download/${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}/$FILE"
 else
   # URL pattern to get latest documented at https://help.github.com/en/articles/linking-to-releases as of 2019-03-29


### PR DESCRIPTION
.NET Core 3.1 has reached end of life as of December 13, 2022, so updating the install scripts to default to the .NET 6.0 version and updating documentation accordingly.

For Windows users can opt into the deprecated version with:
```powershell
iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -InstallNet6:$false"
```

And for Linux/Mac users can opt into the deprecated version with:
```bash
curl -fsSL https://aka.ms/install-artifacts-credprovider.sh | USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER=false bash
```

Note that .NET Core 3.1 has reached [end of life](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core#lifecycle) and will be removed in future versions of the credential provider.