### PR TITLE
Default CanShowDialog to true for stand-alone mode

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviderArgs.cs
+++ b/CredentialProvider.Microsoft/CredentialProviderArgs.cs
@@ -8,9 +8,9 @@ using PowerArgs;
 
 namespace NuGetCredentialProvider
 {
-    [ArgDescription("The Azure Artifacts credential provider can be used to aquire credentials for Azure Artifacts.\n" +
+    [ArgDescription("The Azure Artifacts credential provider can be used to acquire credentials for Azure Artifacts.\n" +
                     "\n" +
-                    "Note: The Azure Artifacts Credential Provider is mainly intended for use via integrations with development tools such as .NET Core and nuget.exe.\n" + 
+                    "Note: The Azure Artifacts Credential Provider is mainly intended for use via integrations with development tools such as .NET Core and nuget.exe.\n" +
                     "While it can be used via this CLI in \"stand-alone mode\", please pay special attention to certain options such as -IsRetry below.\n" +
                     "Failing to do so may result in obtaining invalid credentials.")]
     internal class CredentialProviderArgs
@@ -39,6 +39,7 @@ namespace NuGetCredentialProvider
         [ArgDescription("Prints this help message")]
         public bool Help { get; set; }
 
+        [ArgDefaultValue(true)]
         [ArgDescription("If true, user can be prompted with credentials through UI, if false, device flow must be used")]
         public bool CanShowDialog { get; set; }
 

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
@@ -178,12 +178,18 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public async Task<IMsalToken> AcquireTokenWithUI(CancellationToken cancellationToken, ILogger logging)
         {
+            var publicClient = await GetPCAAsync(useLocalHost: true).ConfigureAwait(false);
+
+            if (!publicClient.IsUserInteractive())
+            {
+                this.Logger.Verbose("Not user interactive");
+                return null;
+            }
+
             var deviceFlowTimeout = EnvUtil.GetDeviceFlowTimeoutFromEnvironmentInSeconds(logging);
 
             using CancellationTokenSource cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
             cts.CancelAfter(TimeSpan.FromSeconds(deviceFlowTimeout));
-
-            var publicClient = await GetPCAAsync(useLocalHost: true).ConfigureAwait(false);
 
             try
             {

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -7,7 +7,6 @@ using System.Collections.Generic;
 using System.IO;
 using System.Net.Http.Headers;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Newtonsoft.Json;


### PR DESCRIPTION
Turning off the CanShowDialog option is meant to be used to force a device code flow, generally only in cases where an interactive prompt can't be used (like headless displays). These cases are fairly rare and the system browser flow has a good experience and is cross platform. And for Windows the WAM Broker account picker is even better as it prompts with configured and cached accounts.

Changing the default for stand-alone mode only so users can get the benefits if tooling is not explicitly disabling the option. Not changing the default for the NuGet protocol at this time, following up with that team on a change to the protocol.