### PR TITLE
Always run MsalSilentBearerTokenProvider to provide cached and refreshed tokens

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalBearerTokenProviders.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalBearerTokenProviders.cs
@@ -3,11 +3,9 @@
 // Licensed under the MIT license.
 
 using System;
-using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Identity.Client;
-using NuGetCredentialProvider.Logging;
 using NuGetCredentialProvider.Util;
 
 namespace NuGetCredentialProvider.CredentialProviders.Vsts
@@ -34,7 +32,11 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public bool ShouldRun(bool isRetry, bool isNonInteractive, bool canShowDialog)
         {
-            return !isRetry;
+            // Always run this and rely on MSAL to return a valid token. Previously, AcquireTokenByIntegratedWindowsAuth
+            // would return cached tokens based on the user principal name, so this token provider could be skipped. Now,
+            // cached and broker accounts and any cached tokens are returned via AcquireTokenSilent. MSAL will ensure any
+            // returned token is refreshed as needed to be valid upon return.
+            return true;
         }
     }
 
@@ -86,7 +88,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public bool ShouldRun(bool isRetry, bool isNonInteractive, bool canShowDialog)
         {
-            // MSAL will use the system browser, this will work on ALL os's
+            // MSAL will use the system browser, this will work on all OS's
             return !isNonInteractive && canShowDialog;
         }
     }


### PR DESCRIPTION
Previously in ADAL AdalCacheBearerTokenProvider would be skipped if IsRetry was true, but rely on WindowsIntegratedAuthBearerTokenProvider to provide a cached token. In the MSAL variants, MsalSilentBearerTokenProvider would also be skipped if IsRetry was true, but in this case MsalWindowsIntegratedAuthBearerTokenProvider does not provide cached tokens, leading to a prompt.

In MSAL the AcquireTokenSilent calls obtain cached or refreshed tokens for both brokered and non-broker cases, and we should rely on the fact that this will always return a valid token. So MsalSilentBearerTokenProvider should always be run to provide cached tokens.

The context here is that we've seen some bad cases where NuGet clients are dropping or invalidating access tokens, getting Unauthorized (401) responses from external endpoints, then calling back into the credential provider for new tokens. These cases require both the token cache and/or silent authentication to be enabled otherwise users get constant prompts during package restore.