### PR TITLE
Upgrade MSAL dependencies to GA versions

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -28,10 +28,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.50.0" />
-    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.50.0-preview"/>
-    <PackageReference Include="Microsoft.Identity.Client.NativeInterop" Version="0.13.5"/>
-    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.26.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.52.0" />
+    <PackageReference Include="Microsoft.Identity.Client.Broker" Version="4.52.0"/>
+    <PackageReference Include="Microsoft.Identity.Client.Extensions.Msal" Version="2.28.0" />
     <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="5.2.9" />
     <PackageReference Include="NuGet.Protocol" Version="5.11.3" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
@@ -257,14 +257,13 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                     this.Logger.Verbose($"MSAL using WithBrokerPreview");
 
                     publicClientBuilder
-                        .WithBrokerPreview()
-                        .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow())
-                        .WithWindowsBrokerOptions(new WindowsBrokerOptions()
+                        .WithBroker(new BrokerOptions(BrokerOptions.OperatingSystems.Windows)
                         {
-                            HeaderText = "Azure DevOps Artifacts",
-                            ListWindowsWorkAndSchoolAccounts = true,
+                            Title = "Azure DevOps Artifacts",
+                            ListOperatingSystemAccounts = true,
                             MsaPassthrough = true
-                        });
+                        })
+                        .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow());
                 }
                 else
                 {
@@ -283,7 +282,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             return publicClient;
         }
 
-#region https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/wiki/WAM
+#region https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/3590
         enum GetAncestorFlags
         {
             GetParent = 1,

--- a/CredentialProvider.Microsoft/Util/WindowsIntegratedAuthUtils.cs
+++ b/CredentialProvider.Microsoft/Util/WindowsIntegratedAuthUtils.cs
@@ -6,7 +6,7 @@ namespace NuGetCredentialProvider.Util
 {
     internal static class WindowsIntegratedAuthUtils
     {
-        // Adapted from https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/core/src/Platforms/net45/NetDesktopPlatformProxy.cs
+        // Adapted from https://github.com/AzureAD/azure-activedirectory-library-for-dotnet/blob/dev/src/Microsoft.IdentityModel.Clients.ActiveDirectory/Platforms/net45/NetDesktopPlatformProxy.cs
         [DllImport("secur32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         [return: MarshalAs(UnmanagedType.U1)]
         private static extern bool GetUserNameEx(int nameFormat, StringBuilder userName, ref uint userNameSize);


### PR DESCRIPTION
WAM Broker has reached GA, so updating to the latest package versions and associated code changes for the GA version. The explicit reference to Microsoft.Identity.Client.NativeInterop is no longer needed so dropping that. And found some dead links in the code so updating those as well.