### PR TITLE
Fix valid host check for vanity urls

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/VstsCredentialProviderTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/VstsCredentialProviderTests.cs
@@ -82,10 +82,10 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
             {
                 @"http://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json",
                 @"https://example.pkgs.vsts.me/_packaging/TestFeed/nuget/v3/index.json",
-                @"https://example.pkgs.codedev.ms/_packaging/TestFeed/nuget/v3/index.json",
-                @"https://example.pkgs.codeapp.ms/_packaging/TestFeed/nuget/v3/index.json",
+                @"https://pkgs.codedev.ms/example/_packaging/TestFeed/nuget/v3/index.json",
+                @"https://pkgs.codeapp.ms/example/_packaging/TestFeed/nuget/v3/index.json",
                 @"https://example.pkgs.visualstudio.com/_packaging/TestFeed/nuget/v3/index.json",
-                @"https://example.pkgs.dev.azure.com/_packaging/TestFeed/nuget/v3/index.json",
+                @"https://pkgs.dev.azure.com/example/_packaging/TestFeed/nuget/v3/index.json",
             };
 
             foreach (var source in sources)
@@ -100,7 +100,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         }
 
         [TestMethod]
-        public async Task CanProvideCredentials_ReturnsTrueForOverridenSources()
+        public async Task CanProvideCredentials_ReturnsTrueForOverriddenSources()
         {
             var sources = new[]
             {
@@ -113,7 +113,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
             foreach (var source in sources)
             {
                 var canProvideCredentials = await vstsCredentialProvider.CanProvideCredentialsAsync(source);
-                canProvideCredentials.Should().BeTrue($"because {source} is an overriden host");
+                canProvideCredentials.Should().BeTrue($"because {source} is an overridden host");
             }
 
             mockAuthUtil

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -49,16 +49,18 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 return false;
             }
 
-             var validHosts = EnvUtil.GetHostsFromEnvironment(Logger, EnvUtil.SupportedHostsEnvVar, new[]
-             {
-                 ".pkgs.vsts.me", // DevFabric
-                 ".pkgs.codedev.ms", // DevFabric
-                 ".pkgs.codeapp.ms", // AppFabric
-                 ".pkgs.visualstudio.com", // Prod
-                 ".pkgs.dev.azure.com" // Prod
-             });
+            var validHosts = EnvUtil.GetHostsFromEnvironment(Logger, EnvUtil.SupportedHostsEnvVar, new[]
+            {
+                ".pkgs.vsts.me", // DevFabric
+                "pkgs.codedev.ms", // DevFabric
+                "pkgs.codeapp.ms", // AppFabric
+                ".pkgs.visualstudio.com", // Prod
+                "pkgs.dev.azure.com" // Prod
+            });
 
-            bool isValidHost = validHosts.Any(host => uri.Host.EndsWith(host, StringComparison.OrdinalIgnoreCase));
+            bool isValidHost = validHosts.Any(host => host.StartsWith(".") ?
+                uri.Host.EndsWith(host, StringComparison.OrdinalIgnoreCase) :
+                uri.Host.Equals(host, StringComparison.OrdinalIgnoreCase));
             if (isValidHost)
             {
                 Verbose(string.Format(Resources.HostAccepted, uri.Host));


### PR DESCRIPTION
The valid host checks ensure we don't make an extra http probe, but no longer correctly handle the vanity url changes where the organization is no longer part of the host name. Double checked old and new style urls for DevFabric, AppFabric, and prod.