### PR TITLE
Add devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "image": "mcr.microsoft.com/devcontainers/dotnet:6.0",
+  "features": {
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,8 @@
 {
   "image": "mcr.microsoft.com/devcontainers/dotnet:6.0",
   "features": {
+    "ghcr.io/devcontainers/features/dotnet:1": {
+      "version": "3.1"
+    }
   }
 }


### PR DESCRIPTION
Add default devcontainer.json to enable the repository to build in Codespaces. This builds from the dotnet 6.0 images and adds .NET Core 3.1. The repository is able to build, run, and test if using .NET 6.0 (probably .NET Core 3.1 as well but untested). .NET Framework requires mono to run but didn't see any convenient features for that.

The default devcontainer image contains .NET 7.0 but the container is unable to pull or build by default if the latest SDKs are not already present in the artifacts feed. Since only a single version of .NET can be installed using their feature support, going with the changes here. Once .NET Core 3.1 is dropped we can switch back to the default image + a .NET 6.0 feature.