### PR TITLE
Add http client factory and user agent to identity provider requests

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/AdalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/AdalTokenProvider.cs
@@ -32,7 +32,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public async Task<IAdalToken> AcquireTokenWithDeviceFlowAsync(Func<DeviceCodeResult, Task> deviceCodeHandler, CancellationToken cancellationToken, ILogger logger)
         {
-            var authenticationContext = new AuthenticationContext(authority, tokenCache);
+            var authenticationContext = new AuthenticationContext(authority, validateAuthority: true, tokenCache, HttpClientFactory.Default);
 
             var deviceCode = await authenticationContext.AcquireDeviceCodeAsync(resource, clientId);
             cancellationToken.ThrowIfCancellationRequested();
@@ -61,7 +61,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public async Task<IAdalToken> AcquireTokenSilentlyAsync(CancellationToken cancellationToken)
         {
-            var authenticationContext = new AuthenticationContext(authority, tokenCache);
+            var authenticationContext = new AuthenticationContext(authority, validateAuthority: true, tokenCache, HttpClientFactory.Default);
 
             try
             {
@@ -81,7 +81,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
         {
 #if NETFRAMEWORK
-            var authenticationContext = new AuthenticationContext(authority, tokenCache);
+            var authenticationContext = new AuthenticationContext(authority, validateAuthority: true, tokenCache, HttpClientFactory.Default);
 
             var parameters = new PlatformParameters(PromptBehavior.Always);
 
@@ -109,7 +109,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
 
         public async Task<IAdalToken> AcquireTokenWithWindowsIntegratedAuth(CancellationToken cancellationToken)
         {
-            var authenticationContext = new AuthenticationContext(authority, tokenCache);
+            var authenticationContext = new AuthenticationContext(authority, validateAuthority: true, tokenCache, HttpClientFactory.Default);
 
             try
             {

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/IAuthUtil.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/IAuthUtil.cs
@@ -144,14 +144,10 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 return headers;
             }
 
-            using (var httpClient = new HttpClient())
+            var httpClient = HttpClientFactory.Default.GetHttpClient();
+
             using (var request = new HttpRequestMessage(HttpMethod.Get, uri))
             {
-                foreach (var userAgent in Program.UserAgent)
-                {
-                    httpClient.DefaultRequestHeaders.UserAgent.Add(userAgent);
-                }
-
                 logger.Verbose($"GET {uri}");
                 using (var response = await httpClient.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, cancellationToken))
                 {

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MSAL/MsalTokenProvider.cs
@@ -247,6 +247,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             var publicClientBuilder = PublicClientApplicationBuilder.Create(this.clientId)
                 .WithAuthority(this.authority)
                 .WithDefaultRedirectUri()
+                .WithHttpClientFactory(HttpClientFactory.Default)
                 .WithLogging(
                     (LogLevel level, string message, bool _containsPii) =>
                     {

--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -29,6 +29,8 @@ namespace NuGetCredentialProvider
         internal static string Name => name.Value;
         internal static string Version => version.Value;
 
+        // Produces a value similar to the following:
+        // CredentialProvider.Microsoft/1.0.4+aae4981de95d543b7935811c05474e393dd9e144 (Windows; X64; Microsoft Windows 10.0.19045) CLR/6.0.16 (.NETCoreApp,Version=v6.0; win10-x64; .NET 6.0.16)
         internal static IList<ProductInfoHeaderValue> UserAgent
         {
             get
@@ -36,23 +38,21 @@ namespace NuGetCredentialProvider
                 return new List<ProductInfoHeaderValue>()
                 {
                     new ProductInfoHeaderValue(Name, Version),
-#if NETFRAMEWORK
-                    new ProductInfoHeaderValue("(netfx)"),
-#else
-                    new ProductInfoHeaderValue("(netcore)"),
-#endif
+                    new ProductInfoHeaderValue($"({PlatformUtils.GetOSType()}; {PlatformUtils.GetCpuArchitecture()}; {PlatformUtils.GetOsDescription()})"),
+                    new ProductInfoHeaderValue("CLR", PlatformUtils.GetClrVersion()),
+                    new ProductInfoHeaderValue($"({PlatformUtils.GetClrFramework()}; {PlatformUtils.GetClrRuntime()}; {PlatformUtils.GetClrDescription()})")
                 };
             }
         }
 
         private static Lazy<string> name = new Lazy<string>(() =>
         {
-            return typeof(Program).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "CredentialProvider.Microsoft";
+            return typeof(Program).Assembly.GetCustomAttribute<AssemblyProductAttribute>()?.Product ?? "CredentialProvider.Microsoft";
         });
 
         private static Lazy<string> version = new Lazy<string>(() =>
         {
-            return typeof(Program).GetTypeInfo().Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "";
+            return typeof(Program).Assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "";
         });
 
         private static bool shuttingDown = false;
@@ -67,6 +67,8 @@ namespace NuGetCredentialProvider
             var fileLogger = GetFileLogger();
             if (fileLogger != null)
             {
+                fileLogger.Log(LogLevel.Verbose, allowOnConsole: false, string.Join(" ", UserAgent));
+
                 multiLogger.Add(fileLogger);
             }
 

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -1,0 +1,41 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System;
+using System.Net.Http;
+using Microsoft.Identity.Client;
+using IAdalHttpClientFactory = Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory;
+
+namespace NuGetCredentialProvider.Util
+{
+    internal class HttpClientFactory : IMsalHttpClientFactory, IAdalHttpClientFactory
+    {
+        private static readonly HttpClient httpClient;
+
+        public static HttpClientFactory Default => new();
+
+        static HttpClientFactory()
+        {
+            // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines
+#if NETFRAMEWORK
+            httpClient = new HttpClient();
+#else
+            httpClient  = new HttpClient(new SocketsHttpHandler
+            {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(15)
+            });
+#endif
+
+            foreach (var item in Program.UserAgent)
+            {
+                httpClient.DefaultRequestHeaders.UserAgent.Add(item);
+            }
+        }
+
+        public HttpClient GetHttpClient()
+        {
+            return httpClient;
+        }
+    }
+}

--- a/CredentialProvider.Microsoft/Util/PlatformUtils.cs
+++ b/CredentialProvider.Microsoft/Util/PlatformUtils.cs
@@ -1,0 +1,72 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System;
+using System.Runtime.InteropServices;
+
+namespace NuGetCredentialProvider.Util
+{
+    internal static class PlatformUtils
+    {
+        public static string GetOSType()
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                return nameof(OSPlatform.Windows);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                return nameof(OSPlatform.Linux);
+            }
+
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                return nameof(OSPlatform.OSX);
+            }
+
+            return "Unknown";
+        }
+
+        public static string GetCpuArchitecture()
+        {
+            return RuntimeInformation.OSArchitecture.ToString();
+        }
+
+        public static string GetOsDescription()
+        {
+            return RuntimeInformation.OSDescription;
+        }
+
+        public static string GetClrVersion()
+        {
+            return Environment.Version.ToString();
+        }
+
+        public static string GetClrFramework()
+        {
+#if NETFRAMEWORK
+            return ".NETFramework,Version=v4.6.1";
+#else
+            return AppContext.TargetFrameworkName;
+#endif
+        }
+
+        public static string GetClrRuntime()
+        {
+#if NETFRAMEWORK
+            return "win-x64";
+#elif NETCOREAPP3_1
+            return AppContext.GetData("RUNTIME_IDENTIFIER") as string ?? "unknown";
+#else
+            return RuntimeInformation.RuntimeIdentifier;
+#endif
+        }
+
+        public static string GetClrDescription()
+        {
+            return RuntimeInformation.FrameworkDescription;
+        }
+    }
+}


### PR DESCRIPTION
When using MSAL or ADAL authentication libraries no attempt is done to populate the UserAgent header when making requests, and no great API is provided to easily set this. The only mechanism is to implement their IHttpClientFactory interface and customize the HttpClients being used by the library. As such I'm taking this opportunity to use this factory to return a singleton instance for use in all places that we're making HTTP requests.

Additionally I'm updating the UserAgent header we're sending to include more information about the platform and runtime, which now produces a header that looks like the following: ```User-Agent: CredentialProvider.Microsoft/1.0.4+aae4981de95d543b7935811c05474e393dd9e144 (Windows; X64; Microsoft Windows 10.0.19045) CLR/6.0.16 (.NETCoreApp,Version=v6.0; win10-x64; .NET 6.0.16)```