### PR TITLE
Enable MSAL by default

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
+++ b/CredentialProvider.Microsoft.Tests/CredentialProviders/Vsts/AuthUtilTests.cs
@@ -48,6 +48,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -58,6 +59,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeadersAndPpe_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -68,6 +70,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task GetAadAuthorityUri_WithoutAuthenticateHeadersAndPpeAndPpeOverride_ReturnsCorrectAuthority()
         {
+            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var ppeUris = new[]
             {
                 new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json"),
@@ -80,6 +83,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
             foreach (var ppeUri in ppeUris)
             {
                 var authorityUri = await authUtil.GetAadAuthorityUriAsync(ppeUri, cancellationToken);
+
                 authorityUri.Should().Be(new Uri("https://login.windows-ppe.net/common"));
             }
         }
@@ -104,7 +108,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
             MockAadAuthorityHeaders(testAuthority);
 
-            Environment.SetEnvironmentVariable(EnvUtil.AuthorityEnvVar, overrideAuthority.ToString());
+            Environment.SetEnvironmentVariable(EnvUtil.MsalAuthorityEnvVar, overrideAuthority.ToString());
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
 
             authorityUri.Should().Be(overrideAuthority);
@@ -200,8 +204,6 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task MsalGetAadAuthorityUri_WithoutAuthenticateHeadersAndPpeAndPpeOverride_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
-
             var ppeUris = new[]
             {
                 new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json"),
@@ -220,9 +222,8 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         }
 
         [TestMethod]
-        public async Task MsaltAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
+        public async Task MsalAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);
@@ -232,7 +233,7 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
 
 
         [TestMethod]
-        public async Task MsaltAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthorityFalseEnvVar()
+        public async Task MsalAadAuthorityUri_WithoutAuthenticateHeaders_ReturnsCorrectAuthorityFalseEnvVar()
         {
             Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "false");
             var requestUri = new Uri("https://example.pkgs.visualstudio.com/_packaging/feed/nuget/v3/index.json");
@@ -245,7 +246,6 @@ namespace CredentialProvider.Microsoft.Tests.CredentialProviders.Vsts
         [TestMethod]
         public async Task MsalGetAadAuthorityUri_WithoutAuthenticateHeadersAndPpe_ReturnsCorrectAuthority()
         {
-            Environment.SetEnvironmentVariable(EnvUtil.MsalEnabledEnvVar, "true");
             var requestUri = new Uri("https://example.pkgs.vsts.me/_packaging/feed/nuget/v3/index.json");
 
             var authorityUri = await authUtil.GetAadAuthorityUriAsync(requestUri, cancellationToken);

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -110,7 +110,7 @@ namespace NuGetCredentialProvider.Util
 
         internal static bool MsalEnabled()
         {
-            return GetEnabledFromEnvironment(MsalEnabledEnvVar, defaultValue: false);
+            return GetEnabledFromEnvironment(MsalEnabledEnvVar, defaultValue: true);
         }
 
         public static bool MsalFileCacheEnabled()


### PR DESCRIPTION
Turning on MSAL by default per the discussion in https://github.com/microsoft/artifacts-credprovider/discussions/394, with the goal of deprecating Azure Active Directory Authentication Library (ADAL) usage. ADAL can be turned back on by:

```shell
# Windows
set NUGET_CREDENTIALPROVIDER_MSAL_ENABLED=false

# Linux/macOS
export NUGET_CREDENTIALPROVIDER_MSAL_ENABLED=false
```