### PR TITLE
Remove duplicate UserAgent header values

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), Build.props))\Build.props" />
 
   <PropertyGroup>
+    <LangVersion>latest</LangVersion>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
+++ b/CredentialProvider.Microsoft.Tests/Logging/LoggingTests.cs
@@ -1,4 +1,8 @@
-﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Moq;
 using NuGet.Common;
 using NuGetCredentialProvider.Logging;

--- a/CredentialProvider.Microsoft.Tests/Util/HttpClientFactoryTests.cs
+++ b/CredentialProvider.Microsoft.Tests/Util/HttpClientFactoryTests.cs
@@ -1,0 +1,28 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using System.Linq;
+using Microsoft.Artifacts.Authentication;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using NuGetCredentialProvider.Util;
+
+namespace CredentialProvider.Microsoft.Tests.Util;
+
+[TestClass]
+public class HttpClientFactoryTests
+{
+    [TestMethod]
+    public void HttpClientFactory_UserAgent()
+    {
+        var httpClientFactory = HttpClientFactory.Default;
+        var httpClient = httpClientFactory.GetHttpClient();
+        var userAgent = httpClient.DefaultRequestHeaders.UserAgent;
+
+        Assert.AreEqual(4, userAgent.Count);
+        Assert.AreEqual(MsalHttpClientFactory.ProgramProduct, userAgent.ElementAt(0));
+        Assert.AreEqual(MsalHttpClientFactory.ProgramComment, userAgent.ElementAt(1));
+        Assert.AreEqual(MsalHttpClientFactory.ClrProduct, userAgent.ElementAt(2));
+        Assert.AreEqual(MsalHttpClientFactory.ClrComment, userAgent.ElementAt(3));
+    }
+}

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -9,7 +9,7 @@ using IAdalHttpClientFactory = Microsoft.IdentityModel.Clients.ActiveDirectory.I
 
 namespace NuGetCredentialProvider.Util
 {
-    internal class HttpClientFactory : MsalHttpClientFactory, IAdalHttpClientFactory
+    public class HttpClientFactory : MsalHttpClientFactory, IAdalHttpClientFactory
     {
         private static readonly HttpClientFactory httpClientFactory;
 

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -31,11 +31,6 @@ namespace NuGetCredentialProvider.Util
             });
 #endif
 
-            foreach (var item in MsalHttpClientFactory.UserAgent)
-            {
-                httpClient.DefaultRequestHeaders.UserAgent.Add(item);
-            }
-
             httpClientFactory = new(httpClient);
         }
     }

--- a/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
+++ b/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
@@ -1,0 +1,48 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+namespace Microsoft.Artifacts.Authentication.Tests;
+
+[TestClass]
+public class MsalHttpClientFactoryTests
+{
+    [TestMethod]
+    public void GetHttpClientTest()
+    {
+        var httpClient = new HttpClient();
+        var httpClientFactory = new MsalHttpClientFactory(httpClient);
+
+        Assert.AreEqual(httpClient, httpClientFactory.GetHttpClient());
+    }
+
+    [TestMethod]
+    public void UserAgentTest()
+    {
+        var httpClientFactory = new MsalHttpClientFactory(new HttpClient());
+        var httpClient = httpClientFactory.GetHttpClient();
+        var userAgent = httpClient.DefaultRequestHeaders.UserAgent;
+
+        Assert.AreEqual(4, userAgent.Count);
+
+        var programProduct = userAgent.ElementAt(0);
+        Assert.IsNotNull(programProduct.Product);
+        Assert.AreEqual(MsalHttpClientFactory.ProgramProduct, programProduct);
+        Assert.AreEqual(PlatformInformation.GetProgramName(), programProduct.Product.Name);
+        Assert.AreEqual(PlatformInformation.GetProgramVersion(), programProduct.Product.Version);
+
+        var programComment = userAgent.ElementAt(1);
+        Assert.AreEqual(MsalHttpClientFactory.ProgramComment, programComment);
+        Assert.AreEqual($"({PlatformInformation.GetOSType()}; {PlatformInformation.GetCpuArchitecture()}; {PlatformInformation.GetOsDescription()})", programComment.Comment);
+
+        var clrProduct = userAgent.ElementAt(2);
+        Assert.IsNotNull(clrProduct.Product);
+        Assert.AreEqual(MsalHttpClientFactory.ClrProduct, clrProduct);
+        Assert.AreEqual("CLR", clrProduct.Product.Name);
+        Assert.AreEqual(PlatformInformation.GetClrVersion(), clrProduct.Product.Version);
+
+        var clrComment = userAgent.ElementAt(3);
+        Assert.AreEqual(MsalHttpClientFactory.ClrComment, clrComment);
+        Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()})", clrComment.Comment);
+    }
+}


### PR DESCRIPTION
The MsalHttpClientFactory class already adds the UserAgent header values when used, so can remove the ones added in Util/HttpClientFactory.