### PR TITLE
Use default credentials on http client handler

### DIFF
--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -2,8 +2,6 @@
 //
 // Licensed under the MIT license.
 
-using System;
-using System.Net;
 using System.Net.Http;
 using Microsoft.Artifacts.Authentication;
 using IAdalHttpClientFactory = Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory;

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -29,11 +29,12 @@ namespace NuGetCredentialProvider.Util
                 UseDefaultCredentials = true
             });
 #else
-            var httpClient  = new HttpClient(new SocketsHttpHandler
-            {
-                PooledConnectionLifetime = TimeSpan.FromMinutes(15),
-                DefaultProxyCredentials = CredentialCache.DefaultCredentials
-            });
+            var httpClient = new HttpClient(
+                new SocketsHttpHandler
+                {
+                    PooledConnectionLifetime = TimeSpan.FromMinutes(15),
+                    Credentials = CredentialCache.DefaultCredentials,
+                });
 #endif
 
             httpClientFactory = new(httpClient);

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -22,20 +22,12 @@ namespace NuGetCredentialProvider.Util
 
         static HttpClientFactory()
         {
-            // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines
-#if NETFRAMEWORK
             var httpClient = new HttpClient(new HttpClientHandler
             {
+                // This is needed to make IWA work. See:
+                // https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/blob/e15befb5f0a6cf4757c5abcaa6487e28e7ebd1bb/src/client/Microsoft.Identity.Client/PlatformsCommon/Shared/SimpleHttpClientFactory.cs#LL26C1-L27C73
                 UseDefaultCredentials = true
             });
-#else
-            var httpClient = new HttpClient(
-                new SocketsHttpHandler
-                {
-                    PooledConnectionLifetime = TimeSpan.FromMinutes(15),
-                    Credentials = CredentialCache.DefaultCredentials,
-                });
-#endif
 
             httpClientFactory = new(httpClient);
         }

--- a/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
+++ b/CredentialProvider.Microsoft/Util/HttpClientFactory.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Net;
 using System.Net.Http;
 using Microsoft.Artifacts.Authentication;
 using IAdalHttpClientFactory = Microsoft.IdentityModel.Clients.ActiveDirectory.IHttpClientFactory;
@@ -23,11 +24,15 @@ namespace NuGetCredentialProvider.Util
         {
             // https://learn.microsoft.com/en-us/dotnet/fundamentals/networking/http/httpclient-guidelines
 #if NETFRAMEWORK
-            var httpClient = new HttpClient();
+            var httpClient = new HttpClient(new HttpClientHandler
+            {
+                UseDefaultCredentials = true
+            });
 #else
             var httpClient  = new HttpClient(new SocketsHttpHandler
             {
-                PooledConnectionLifetime = TimeSpan.FromMinutes(15)
+                PooledConnectionLifetime = TimeSpan.FromMinutes(15),
+                DefaultProxyCredentials = CredentialCache.DefaultCredentials
             });
 #endif
 


### PR DESCRIPTION
MSAL integrated Windows authentication requires using default credentials. This is done if using MSALs http client factory, so must explicitly opt into this behavior.