### PR TITLE
Fix authentication assembly signing

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -52,16 +52,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <FilesToSign Include="$(OutDir)$(TargetFileName)">
-      <Authenticode>Microsoft400</Authenticode>
-      <StrongName>StrongName</StrongName>
-    </FilesToSign>
-    <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)">
-      <Authenticode>Microsoft400</Authenticode>
-      <StrongName>StrongName</StrongName>
-    </FilesToSign>
-    <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' ">
-      <Authenticode>Microsoft400</Authenticode>
-    </FilesToSign>
+    <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(IntermediateOutputPath)Microsoft.Artifacts.Authentication.dll" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
   </ItemGroup>
 </Project>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -53,7 +53,6 @@
 
   <ItemGroup>
     <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
-    <FilesToSign Include="$(OutDir)Microsoft.Artifacts.Authentication.dll" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
   </ItemGroup>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -53,8 +53,8 @@
 
   <ItemGroup>
     <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$(OutDir)Microsoft.Artifacts.Authentication.dll" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
-    <FilesToSign Include="$(IntermediateOutputPath)Microsoft.Artifacts.Authentication.dll" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
   </ItemGroup>
 </Project>

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -37,6 +37,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
   </ItemGroup>
 


### PR DESCRIPTION
Depending on the operation outputs are either pulled from the project intermediate directory (e.g. in publish) or the output directory. Since signing occurs after the build, the unsigned assembly has been copied to the output directory so needs to be signed there as well.