### PR TITLE
Bump NuGet.Protocol package version to 5.11.5

### DIFF
--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.11.3" />
+    <PackageReference Include="NuGet.Protocol" Version="5.11.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
+++ b/CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj
@@ -12,7 +12,6 @@
     <PackageReference Include="Moq" Version="4.13.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
     <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.11.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -30,10 +30,10 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
-    <PackageReference Include="NuGet.Protocol" Version="5.11.3" />
-    <PackageReference Include="PowerArgs" Version="3.6.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
+    <PackageReference Include="NuGet.Protocol" Version="5.11.5" />
+    <PackageReference Include="PowerArgs" Version="3.6.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.7" />
   </ItemGroup>
 


### PR DESCRIPTION
Bumping NuGet.Protocol version and removing explicit dependency where not required as dependabot doesn't update all projects at once.