### PR TITLE
Add explicit version for Newtonsoft.Json

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -32,6 +32,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="6.0.0" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0-beta2-19554-01" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NuGet.Protocol" Version="5.11.5" />
     <PackageReference Include="PowerArgs" Version="3.6.0" />
     <PackageReference Include="System.Text.Json" Version="6.0.7" />


### PR DESCRIPTION
NuGet brings in very old versions of Newtonsoft.Json. Need to look at upgrading NuGet dependencies, but in the meantime, bring back the explicit version.