### PR TITLE
Standardize versions in project files

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -15,4 +15,4 @@ variables:
 steps:
 - template: build/build.yml
   parameters:
-    nuspecProperties: 'VersionSuffix=-CI-$(Build.BuildNumber)'
+    nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -13,4 +13,4 @@ variables:
 steps:
 - template: build/build.yml
   parameters:
-    nuspecProperties: 'VersionSuffix=-PR-$(Build.BuildNumber)'
+    nuspecProperties: 'VersionSuffix=PR-$(Build.BuildNumber)'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ dotnet pack CredentialProvider.Microsoft --configuration Release
 For CI builds, you can append a pre-release version:
 
 ```shell
-dotnet pack CredentialProvider.Microsoft --configuration Release /p:NuspecProperties=VersionSuffix=-MyCustomVersion-2
+dotnet pack CredentialProvider.Microsoft --configuration Release /p:NuspecProperties=VersionSuffix=MyCustomVersion-2
 ```
 
 ### Versioning

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -5,11 +5,11 @@
     <RootNamespace>NuGetCredentialProvider</RootNamespace>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>helpericons.ico</ApplicationIcon>
-    <Version>$(CredentialProviderVersion)</Version>
-    <PackageVersion>$(CredentialProviderVersion)</PackageVersion>
+    <VersionPrefix>$(CredentialProviderVersion)</VersionPrefix>
     <NuspecFile>CredentialProvider.Microsoft.nuspec</NuspecFile>
-    <!-- Shouldn't need to set these explicitly, there may be a bug in dotnet pack -->
-    <NuspecProperties>$(NuspecProperties);Configuration=$(Configuration);Version=$(CredentialProviderVersion)$(VersionSuffix)</NuspecProperties>
+    <!-- Need to set properties explictly when using nuspec https://github.com/NuGet/Home/issues/6636#issuecomment-443280306 -->
+    <NuspecProperties Condition=" '$(VersionSuffix)' == '' ">$(NuspecProperties);Configuration=$(Configuration);Version=$(VersionPrefix)</NuspecProperties>
+    <NuspecProperties Condition=" '$(VersionSuffix)' != '' ">$(NuspecProperties);Configuration=$(Configuration);Version=$(VersionPrefix)-$(VersionSuffix)</NuspecProperties>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
@@ -2,7 +2,7 @@
 <package>
   <metadata>
     <id>Microsoft.NuGet.CredentialProvider</id>
-    <version>$Version$$VersionSuffix$</version>
+    <version>$Version$</version>
     <title>Microsoft Credential Provider for NuGet</title>
     <authors>Microsoft</authors>
     <owners>microsoft,nugetvss</owners>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -23,4 +23,12 @@
     </EmbeddedResource>
   </ItemGroup>
 
+  <!--
+      Support for command line evaluation of properties
+      https://github.com/dotnet/msbuild/issues/3911#issuecomment-1478468822
+  -->
+  <Target Name="PrintVersion">
+    <Message Text="$(MSBuildProjectName):$(Version)$(VersionSuffix)" Importance="High" />
+  </Target>
+
 </Project>

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -28,7 +28,7 @@
       https://github.com/dotnet/msbuild/issues/3911#issuecomment-1478468822
   -->
   <Target Name="PrintVersion">
-    <Message Text="$(MSBuildProjectName):$(Version)$(VersionSuffix)" Importance="High" />
+    <Message Text="$(MSBuildProjectName):$(Version)" Importance="High" />
   </Target>
 
 </Project>

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.1.2$(VersionSuffix)</Version>
+    <VersionPrefix>0.1.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>


### PR DESCRIPTION
Adds a target to output the computed version for each project, and attempts to standardize how versions are composed. Specifically the project system supports automatically computing Version/PackageVersion/etc. with the right values if VersionPrefix and VersionSuffix are specified (different outputs have separate requirements for what formats are supported).