### PR TITLE
Adding installcredprovider.ps1 to MicroBuild signing targeted files.

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -42,6 +42,7 @@
 
   <ItemGroup>
     <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
+    <FilesToSign Include="$([System.IO.Path]::Combine($(MSBuildProjectDirectory), `helpers`, `installcredprovider.ps1`))" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
   </ItemGroup>


### PR DESCRIPTION
This PR should result in installcredprovider.ps1 being signed by MicroBuild during the credential provider build process. The primary benefit of this is the signature of the script can be checked before installation.