### PR TITLE
Fix Null Reference Exception

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -136,7 +136,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
                 try
                 {
                     var result = await tokenProvider.GetTokenAsync(tokenRequest, cancellationToken);
-                    bearerToken = result.AccessToken;
+                    bearerToken = result?.AccessToken;
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
- Added a null check when accessing the token result which can be null if there is an underlying MSAL or tokenprovider error. 
- related to issue #455 