### PR TITLE
Changing away from MicroBuildUploadVstsDropFolder@2

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -213,5 +213,6 @@ steps:
   - task: PublishPipelineArtifact@1
     displayName: Publish Artifact $(Build.BuildNumber)
     inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
-      ArtifactName: '$(Build.BuildNumber)'
+      artifact: '$(Build.BuildNumber)'
+      targetPath: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
+

--- a/build/build.yml
+++ b/build/build.yml
@@ -219,9 +219,3 @@ steps:
     inputs:
       BuildDropPath: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
       Verbosity: Verbose
-
-  - task: PublishBuildArtifacts@1
-    displayName: Publish Artifact $(Build.BuildNumber)
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
-      ArtifactName: '$(Build.BuildNumber)'

--- a/build/build.yml
+++ b/build/build.yml
@@ -23,17 +23,6 @@ steps:
   displayName: NuGet Authenticate
 
 - ${{ if eq(parameters.sign, 'true') }}:
-  - task: ms-vseng.MicroBuildTasks.30666190-6959-11e5-9f96-f56098202fef.MicroBuildSigningPlugin@4
-    displayName: Install Signing Plugin
-    inputs:
-      signType: '$(SignType)'
-      feedSource: 'https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json'
-
-  - task: ms-vseng.MicroBuildTasks.32f78468-e895-4f47-962c-58a699361df8.MicroBuildSwixPlugin@4
-    displayName: Install Swix Plugin
-    inputs:
-      feedSource: 'https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json'
-
   - script: nuget restore packages.config -PackagesDirectory packages
     displayName: NuGet restore
     workingDirectory: CredentialProvider.Microsoft.VSIX
@@ -206,16 +195,10 @@ steps:
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
   displayName: Clear SignType
 
-- script: dotnet pack MicrosoftCredentialProvider.sln -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
+- script: dotnet pack MicrosoftCredentialProvider.sln -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }} --version-suffix beta
   displayName: dotnet pack
 
 - ${{ if eq(parameters.publish, 'true') }}:
   - script: dotnet nuget push $(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\*.nupkg --source artifacts-credprovider --api-key az --skip-duplicate
     displayName: dotnet push
     condition: eq(variables['PushNupkg'], 'true')
-
-  - task: ManifestGeneratorTask@0
-    displayName: 'SBOM Generator'
-    inputs:
-      BuildDropPath: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
-      Verbosity: Verbose

--- a/build/build.yml
+++ b/build/build.yml
@@ -209,3 +209,9 @@ steps:
   - script: dotnet nuget push $(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\*.nupkg --source artifacts-credprovider --api-key az --skip-duplicate
     displayName: dotnet push
     condition: eq(variables['PushNupkg'], 'true')
+
+  - task: PublishPipelineArtifact@1
+    displayName: Publish Artifact $(Build.BuildNumber)
+    inputs:
+      PathtoPublish: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\'
+      ArtifactName: '$(Build.BuildNumber)'

--- a/build/build.yml
+++ b/build/build.yml
@@ -203,13 +203,6 @@ steps:
       ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME: 'microsoft'
       ARTIFACTSERVICES_SYMBOL_USEAAD: 'false'
 
-- ${{ if eq(parameters.publish, 'true') }}:
-  - task: PublishPipelineArtifact@1
-    displayName: 'Upload symbols'
-    inputs:
-      artifact: "Symbols"
-      targetPath: '$(Build.ArtifactStagingDirectory)\symbols'
-
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
   displayName: Clear SignType
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -192,6 +192,13 @@ steps:
       ARTIFACTSERVICES_SYMBOL_ACCOUNTNAME: 'microsoft'
       ARTIFACTSERVICES_SYMBOL_USEAAD: 'false'
 
+- ${{ if eq(parameters.publish, 'true') }}:
+  - task: PublishPipelineArtifact@1
+    displayName: 'Upload symbols'
+    inputs:
+      artifact: "Symbols"
+      targetPath: '$(Build.ArtifactStagingDirectory)\symbols'
+
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
   displayName: Clear SignType
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -63,12 +63,10 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\ /p:TreatWarningsAsErrors=true'
 
-  - task: ms-vseng.MicroBuildTasks.4305a8de-ba66-4d8b-b2d1-0dc4ecbbf5e8.MicroBuildUploadVstsDropFolder@2
-    displayName: Upload VSTS Drop
-    inputs:
-      DropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
-      DropRetentionDays: 365
-      AccessToken: $(DevDivDropManageAccessToken)
+  - output: microBuildVstsDrop
+    dropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
+    dropRetentionDays: 365
+    accessToken: $(DevDivDropManageAccessToken)
 
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test MicrosoftCredentialProvider.sln --logger trx --results-directory $(Agent.TempDirectory)

--- a/build/build.yml
+++ b/build/build.yml
@@ -63,11 +63,6 @@ steps:
       configuration: '$(BuildConfiguration)'
       msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\ /p:TreatWarningsAsErrors=true'
 
-  - output: microBuildVstsDrop
-    dropFolder: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
-    dropRetentionDays: 365
-    accessToken: $(DevDivDropManageAccessToken)
-
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test MicrosoftCredentialProvider.sln --logger trx --results-directory $(Agent.TempDirectory)
     displayName: dotnet test

--- a/build/build.yml
+++ b/build/build.yml
@@ -195,7 +195,7 @@ steps:
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
   displayName: Clear SignType
 
-- script: dotnet pack MicrosoftCredentialProvider.sln -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }} --version-suffix beta
+- script: dotnet pack MicrosoftCredentialProvider.sln -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet pack
 
 - ${{ if eq(parameters.publish, 'true') }}:


### PR DESCRIPTION
Using output method with microBuildVstsDrop instead of MicroBuildUploadVstsDropFolder@2 task for compatibility