### PR TITLE
Enable cross platform session token cache global locking

### DIFF
--- a/CredentialProvider.Microsoft/Program.cs
+++ b/CredentialProvider.Microsoft/Program.cs
@@ -66,7 +66,7 @@ namespace NuGetCredentialProvider
             {
                 IRequestHandlers requestHandlers = new RequestHandlerCollection
                 {
-                    { MessageMethod.GetAuthenticationCredentials, new GetAuthenticationCredentialsRequestHandler(multiLogger, credentialProviders) },
+                    { MessageMethod.GetAuthenticationCredentials, new GetAuthenticationCredentialsRequestHandler(multiLogger, credentialProviders, tokenSource.Token) },
                     { MessageMethod.GetOperationClaims, new GetOperationClaimsRequestHandler(multiLogger, credentialProviders) },
                     { MessageMethod.Initialize, new InitializeRequestHandler(multiLogger) },
                     { MessageMethod.SetLogLevel, new SetLogLevelRequestHandler(multiLogger) },

--- a/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
+++ b/CredentialProvider.Microsoft/RequestHandlers/GetAuthenticationCredentialsRequestHandler.cs
@@ -35,10 +35,10 @@ namespace NuGetCredentialProvider.RequestHandlers
             this.cache = cache;
         }
 
-        public GetAuthenticationCredentialsRequestHandler(ILogger logger, IReadOnlyCollection<ICredentialProvider> credentialProviders)
+        public GetAuthenticationCredentialsRequestHandler(ILogger logger, IReadOnlyCollection<ICredentialProvider> credentialProviders, CancellationToken cancellationToken)
             : this(logger, credentialProviders, null)
         {
-            this.cache = GetSessionTokenCache(logger, CancellationToken);
+            this.cache = GetSessionTokenCache(logger, cancellationToken);
         }
 
         public override async Task<GetAuthenticationCredentialsResponse> HandleRequestAsync(GetAuthenticationCredentialsRequest request)

--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -470,4 +470,7 @@ Provide MSAL Cache Location
   <data name="SessionTokenCacheWriteFail" xml:space="preserve">
     <value>Unable to write token to credential cache. Exception: {0}, Message: {1}</value>
   </data>
+  <data name="SessionTokenCacheCancelMessage" xml:space="preserve">
+    <value>Canceling SessionToken cache operation.</value>
+  </data>
 </root>

--- a/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
+++ b/CredentialProvider.Microsoft/Util/SessionTokenCache.cs
@@ -43,18 +43,13 @@ namespace NuGetCredentialProvider.Util
                                 // We couldn't get the mutex on our first acquisition attempt. Log this so the user knows what we're
                                 // waiting on.
                                 logger.Verbose(Resources.SessionTokenCacheMutexMiss);
-
-                                int index = WaitHandle.WaitAny(new WaitHandle[] { mutex, this.cancellationToken.WaitHandle }, -1);
-
-                                if (index == 1)
+                                while (!mutex.WaitOne(100))
                                 {
-                                    logger.Verbose(Resources.CancelMessage);
-                                    return new Dictionary<string, string>();
-                                }
-                                else if (index == WaitHandle.WaitTimeout)
-                                {
-                                    logger.Verbose(Resources.SessionTokenCacheMutexFail);
-                                    return new Dictionary<string, string>();
+                                    if (this.cancellationToken.IsCancellationRequested)
+                                    {
+                                        logger.Verbose(Resources.SessionTokenCacheCancelMessage);
+                                        return new Dictionary<string, string>();
+                                    }
                                 }
                             }
                         }
@@ -95,16 +90,13 @@ namespace NuGetCredentialProvider.Util
                                 // We couldn't get the mutex on our first acquisition attempt. Log this so the user knows what we're
                                 // waiting on.
                                 logger.Verbose(Resources.SessionTokenCacheMutexMiss);
-
-                                int index = WaitHandle.WaitAny(new WaitHandle[] { mutex, this.cancellationToken.WaitHandle }, -1);
-
-                                if (index == 1)
+                                while (!mutex.WaitOne(100))
                                 {
-                                    logger.Verbose(Resources.CancelMessage);
-                                }
-                                else if (index == WaitHandle.WaitTimeout)
-                                {
-                                    logger.Verbose(Resources.SessionTokenCacheMutexFail);
+                                    if (this.cancellationToken.IsCancellationRequested)
+                                    {
+                                        logger.Verbose(Resources.SessionTokenCacheCancelMessage);
+                                        return;
+                                    }
                                 }
                             }
                         }
@@ -170,16 +162,13 @@ namespace NuGetCredentialProvider.Util
                             // We couldn't get the mutex on our first acquisition attempt. Log this so the user knows what we're
                             // waiting on.
                             logger.Verbose(Resources.SessionTokenCacheMutexMiss);
-
-                            int index = WaitHandle.WaitAny(new WaitHandle[] { mutex, this.cancellationToken.WaitHandle }, -1);
-
-                            if (index == 1)
+                            while (!mutex.WaitOne(100))
                             {
-                                logger.Verbose(Resources.CancelMessage);
-                            }
-                            else if (index == WaitHandle.WaitTimeout)
-                            {
-                                logger.Verbose(Resources.SessionTokenCacheMutexFail);
+                                if (this.cancellationToken.IsCancellationRequested)
+                                {
+                                    logger.Verbose(Resources.SessionTokenCacheCancelMessage);
+                                    return;
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
Bug fix #416 
- Move session token cache file lock to single wait handle.
- Add new session cache specific cancel message so the cancel message is not printed twice.
- Pass cancellation token to credential request handler.
