### PR TITLE
Broker: Add ability to pass parent window handle explicitly for Windows broker auth

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MsalTokenProvidersFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MsalTokenProvidersFactory.cs
@@ -30,7 +30,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             }
 
             var app = AzureArtifacts.CreateDefaultBuilder(authority)
-                .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), logger)
+                .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), EnvUtil.GetMsalBrokerWindowHandle(), logger)
                 .WithHttpClientFactory(HttpClientFactory.Default)
                 .WithLogging(
                     (Microsoft.Identity.Client.LogLevel level, string message, bool containsPii) =>

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
@@ -24,7 +24,7 @@ internal class VstsBuildTaskMsalTokenProvidersFactory : ITokenProvidersFactory
     public Task<IEnumerable<ITokenProvider>> GetAsync(Uri authority)
     {
         var app = AzureArtifacts.CreateDefaultBuilder(authority)
-            .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), logger)
+            .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), EnvUtil.GetMsalBrokerWindowHandle(), logger)
             .WithHttpClientFactory(HttpClientFactory.Default)
             .WithLogging(
                 (level, message, containsPii) =>

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -35,7 +35,7 @@ namespace NuGetCredentialProvider.Util
         public const string MsalFileCacheEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_ENABLED";
         public const string MsalFileCacheLocationEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_LOCATION";
         public const string MsalAllowBrokerEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER";
-        public const string MsalBrokerWindowEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_BROKER_WINDOW";
+        public const string MsalBrokerWindowEnvVar = "ARTIFACTS_CREDENTIALPROVIDER_MSAL_BROKER_WINDOW";
 
         public const string EndpointCredentials = "ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS";
         public const string BuildTaskExternalEndpoints = "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS";

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -35,6 +35,7 @@ namespace NuGetCredentialProvider.Util
         public const string MsalFileCacheEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_ENABLED";
         public const string MsalFileCacheLocationEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_LOCATION";
         public const string MsalAllowBrokerEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER";
+        public const string MsalBrokerWindowEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_BROKER_WINDOW";
 
         public const string EndpointCredentials = "ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS";
         public const string BuildTaskExternalEndpoints = "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS";
@@ -100,6 +101,22 @@ namespace NuGetCredentialProvider.Util
         public static bool MsalAllowBrokerEnabled()
         {
             return GetEnabledFromEnvironment(MsalAllowBrokerEnvVar, defaultValue: RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        }
+
+        public static IntPtr? GetMsalBrokerWindowHandle()
+        {
+            var handleRaw = Environment.GetEnvironmentVariable(MsalBrokerWindowEnvVar);
+            if (handleRaw == null)
+            {
+                return null;
+            }
+
+            if (!long.TryParse(handleRaw, out var numericHandle))
+            {
+                return null;
+            }
+
+            return new IntPtr(numericHandle);
         }
 
         public static IList<string> GetHostsFromEnvironment(ILogger logger, string envVar, IEnumerable<string> defaultHosts, [CallerMemberName] string collectionName = null)

--- a/src/Authentication/AzureArtifacts.cs
+++ b/src/Authentication/AzureArtifacts.cs
@@ -33,7 +33,7 @@ public static class AzureArtifacts
         return builder;
     }
 
-    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, ILogger logger)
+    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, IntPtr? parentWindowHandle, ILogger logger)
     {
         // Eventually will be rolled into CreateDefaultBuilder as using the brokers is desirable
         if (!enableBroker || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -52,6 +52,11 @@ public static class AzureArtifacts
                     MsaPassthrough = true
                 })
             .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow());
+    }
+    
+    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, ILogger logger)
+    {
+        return builder.WithBroker(enableBroker, null, logger);
     }
 
     public static PublicClientApplicationBuilder WithHttpClient(this PublicClientApplicationBuilder builder, HttpClient? httpClient = null)

--- a/src/Authentication/AzureArtifacts.cs
+++ b/src/Authentication/AzureArtifacts.cs
@@ -51,7 +51,7 @@ public static class AzureArtifacts
                     ListOperatingSystemAccounts = true,
                     MsaPassthrough = true
                 })
-            .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow());
+            .WithParentActivityOrWindow(() => parentWindowHandle ?? GetConsoleOrTerminalWindow());
     }
     
     public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, ILogger logger)


### PR DESCRIPTION
We have a headless process that hosts the NuGet credential plugin manager and we are facing issues with the default broker logic which tries to obtain the current process' window handle, as we need to pass a native window handle of another (non-.NET) desktop app process. I think the change will be quite beneficial in such a scenario.

I'm open to discussion in case env-based handle propagation is not the best approach.