### PR TITLE
Add parameterless constructor for Microsoft.Artifacts.Authentication.TokenRequest 

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>1.2.0</CredentialProviderVersion>
+    <CredentialProviderVersion>1.2.1</CredentialProviderVersion>
     <VersionSuffix></VersionSuffix>
     <TargetFrameworks>netcoreapp3.1;net461;net6.0</TargetFrameworks>
   </PropertyGroup>

--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/VstsCredentialProvider.cs
@@ -46,9 +46,9 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             string uriPrefixesStringEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskUriPrefixes);
             string accessTokenEnvVar = Environment.GetEnvironmentVariable(EnvUtil.BuildTaskAccessToken);
 
-            if (string.IsNullOrWhiteSpace(feedEndPointsJsonEnvVar) == false || 
-                string.IsNullOrWhiteSpace(externalFeedEndPointsJsonEnvVar) == false || 
-                string.IsNullOrWhiteSpace(uriPrefixesStringEnvVar) == false || 
+            if (string.IsNullOrWhiteSpace(feedEndPointsJsonEnvVar) == false ||
+                string.IsNullOrWhiteSpace(externalFeedEndPointsJsonEnvVar) == false ||
+                string.IsNullOrWhiteSpace(uriPrefixesStringEnvVar) == false ||
                 string.IsNullOrWhiteSpace(accessTokenEnvVar) == false)
             {
                 Verbose(Resources.BuildTaskCredProviderIsUsedError);
@@ -106,7 +106,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             IEnumerable<ITokenProvider> tokenProviders = await tokenProvidersFactory.GetAsync(authInfo.EntraAuthorityUri);
             cancellationToken.ThrowIfCancellationRequested();
 
-            var tokenRequest = new TokenRequest(request.Uri)
+            var tokenRequest = new TokenRequest()
             {
                 IsRetry = request.IsRetry,
                 IsNonInteractive = request.IsNonInteractive,

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -92,7 +92,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                 IEnumerable<ITokenProvider> tokenProviders = await TokenProvidersFactory.GetAsync(authInfo.EntraAuthorityUri);
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var tokenRequest = new TokenRequest(request.Uri)
+                var tokenRequest = new TokenRequest()
                 {
                     IsRetry = request.IsRetry,
                     IsNonInteractive = true,
@@ -139,7 +139,7 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                         bearerToken,
                         null,
                         MessageResponseCode.Success);
-                } 
+                }
             }
 
             Verbose(string.Format(Resources.BuildTaskEndpointNoMatchingUrl, uriString));

--- a/src/Authentication.Tests/MsalAuthenticationTests.cs
+++ b/src/Authentication.Tests/MsalAuthenticationTests.cs
@@ -35,7 +35,7 @@ public class MsalAuthenticationTests
     public async Task MsalAcquireTokenSilentTest()
     {
         var tokenProvider = new MsalSilentTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         var result = await tokenProvider.GetTokenAsync(tokenRequest);
 
@@ -47,7 +47,7 @@ public class MsalAuthenticationTests
     public async Task MsalAcquireTokenByIntegratedWindowsAuthTest()
     {
         var tokenProvider = new MsalIntegratedWindowsAuthTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         var result = await tokenProvider.GetTokenAsync(tokenRequest);
 
@@ -59,7 +59,7 @@ public class MsalAuthenticationTests
     public async Task MsalAcquireTokenInteractiveTest()
     {
         var tokenProvider = new MsalInteractiveTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         var result = await tokenProvider.GetTokenAsync(tokenRequest);
 
@@ -71,7 +71,7 @@ public class MsalAuthenticationTests
     public async Task MsalAcquireTokenWithDeviceCodeTest()
     {
         var tokenProvider = new MsalDeviceCodeTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         var result = await tokenProvider.GetTokenAsync(tokenRequest);
 
@@ -83,7 +83,7 @@ public class MsalAuthenticationTests
     public async Task MsalAquireTokenWithManagedIdentity()
     {
         var tokenProvider = new MsalManagedIdentityTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
         tokenRequest.ClientId = Environment.GetEnvironmentVariable("ARTIFACTS_CREDENTIALPROVIDER_TEST_CLIENTID");
 
         var result = await tokenProvider.GetTokenAsync(tokenRequest);
@@ -96,7 +96,7 @@ public class MsalAuthenticationTests
     public async Task MsalAquireTokenWithServicePrincipal()
     {
         var tokenProvider = new MsalServicePrincipalTokenProvider(app, logger);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
         tokenRequest.ClientId = Environment.GetEnvironmentVariable("ARTIFACTS_CREDENTIALPROVIDER_TEST_CLIENTID");
         tokenRequest.ClientCertificate = new X509Certificate2(Environment.GetEnvironmentVariable("ARTIFACTS_CREDENTIALPROVIDER_TEST_CERT_PATH") ?? string.Empty);
 

--- a/src/Authentication.Tests/TokenProviderTests.cs
+++ b/src/Authentication.Tests/TokenProviderTests.cs
@@ -16,7 +16,7 @@ public class TokenProviderTests
     public void MsalSilentContractTest()
     {
         var tokenProvider = new MsalSilentTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         Assert.IsNotNull(tokenProvider.Name);
         Assert.IsFalse(tokenProvider.IsInteractive);
@@ -30,7 +30,7 @@ public class TokenProviderTests
     public void MsalIntegratedWindowsAuthContractTest()
     {
         var tokenProvider = new MsalIntegratedWindowsAuthTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
         var windowsIntegratedAuthSupported = Environment.OSVersion.Platform == PlatformID.Win32NT;
 
         Assert.IsNotNull(tokenProvider.Name);
@@ -47,7 +47,7 @@ public class TokenProviderTests
     public void MsalInteractiveContractTest()
     {
         var tokenProvider = new MsalInteractiveTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         Assert.IsNotNull(tokenProvider.Name);
         Assert.IsTrue(tokenProvider.IsInteractive);
@@ -82,7 +82,7 @@ public class TokenProviderTests
     public void MsalDeviceCodeFlowContractTest()
     {
         var tokenProvider = new MsalDeviceCodeTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         Assert.IsNotNull(tokenProvider.Name);
         Assert.IsTrue(tokenProvider.IsInteractive);
@@ -101,7 +101,7 @@ public class TokenProviderTests
             .Returns(new Mock<IAppConfig>().Object);
 
         var tokenProvider = new MsalServicePrincipalTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         Assert.IsNotNull(tokenProvider.Name);
         Assert.IsFalse(tokenProvider.IsInteractive);
@@ -133,7 +133,7 @@ public class TokenProviderTests
             .Returns(new Mock<IAppConfig>().Object);
 
         var tokenProvider = new MsalManagedIdentityTokenProvider(appMock.Object, loggerMock.Object);
-        var tokenRequest = new TokenRequest(PackageUri);
+        var tokenRequest = new TokenRequest();
 
         Assert.IsNotNull(tokenProvider.Name);
         Assert.IsFalse(tokenProvider.IsInteractive);

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.2.0</VersionPrefix>
+    <VersionPrefix>0.2.1</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>

--- a/src/Authentication/TokenRequest.cs
+++ b/src/Authentication/TokenRequest.cs
@@ -9,12 +9,14 @@ namespace Microsoft.Artifacts.Authentication;
 
 public class TokenRequest
 {
+    [Obsolete($"{nameof(uri)} is unused and unnecessary. Use the parameterless constructor instead.")]
     public TokenRequest(Uri uri)
     {
-        this.Uri = uri ?? throw new ArgumentNullException(nameof(uri));
     }
 
-    public Uri Uri { get; }
+    public TokenRequest()
+    {
+    }
 
     public bool IsRetry { get; set; }
 

--- a/src/Authentication/TokenRequest.cs
+++ b/src/Authentication/TokenRequest.cs
@@ -9,7 +9,7 @@ namespace Microsoft.Artifacts.Authentication;
 
 public class TokenRequest
 {
-    [Obsolete($"{nameof(uri)} is unused and unnecessary. Use the parameterless constructor instead.")]
+    [Obsolete($"The uri parameter is unused and unnecessary. Use the parameterless constructor instead.")]
     public TokenRequest(Uri uri)
     {
     }


### PR DESCRIPTION
The `Uri` property in TokenRequest is unused. Remove it to make it less confusing.