### PR TITLE
Don't rebuild during pack

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -180,9 +180,6 @@ steps:
 - script: dotnet pack MicrosoftCredentialProvider.sln --no-build -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet pack
 
-- powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
-  displayName: Clear SignType
-
 - ${{ if eq(parameters.publish, 'true') }}:
   - task: PublishPipelineArtifact@1
     displayName: Publish Artifact $(Build.BuildNumber)

--- a/build/build.yml
+++ b/build/build.yml
@@ -34,7 +34,7 @@ steps:
   inputs:
     solution: 'MicrosoftCredentialProvider.sln'
     configuration: '$(BuildConfiguration)'
-    msbuildArguments: '/t:rebuild /p:TreatWarningsAsErrors=true'
+    msbuildArguments: '/t:rebuild /p:TreatWarningsAsErrors=true /p:${{ parameters.nuspecProperties }}'
 
 - ${{ if eq(parameters.sign, 'true') }}:
   - task: MSBuild@1
@@ -55,7 +55,7 @@ steps:
   - script: dotnet test MicrosoftCredentialProvider.sln --logger trx --results-directory $(Agent.TempDirectory)
     displayName: dotnet test
 
-- script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework net6.0 --configuration $(BuildConfiguration)
+- script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework net6.0 --configuration $(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet publish net6.0
 
 # Create .NET 6.0 release for netcore users
@@ -97,7 +97,7 @@ steps:
     replaceExistingArchive: true
 
 # Clean target folder and create netcore 3.1 and netfx releases
-- script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework netcoreapp3.1 --configuration $(BuildConfiguration)
+- script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework netcoreapp3.1 --configuration $(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet publish netcoreapp3.1
 
 - task: CopyFiles@2
@@ -177,11 +177,11 @@ steps:
       **\Microsoft.Artifacts.Authentication.pdb
     TargetFolder: '$(Build.ArtifactStagingDirectory)\symbols'
 
+- script: dotnet pack MicrosoftCredentialProvider.sln --no-build -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
+  displayName: dotnet pack
+
 - powershell: 'Write-Output ("##vso[task.setvariable variable=SignType;]")'
   displayName: Clear SignType
-
-- script: dotnet pack MicrosoftCredentialProvider.sln -c $(BuildConfiguration) -o $(Build.ArtifactStagingDirectory)\$(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
-  displayName: dotnet pack
 
 - ${{ if eq(parameters.publish, 'true') }}:
   - task: PublishPipelineArtifact@1

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <VersionPrefix>0.2.1</VersionPrefix>
+    <VersionPrefix>0.2.2</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>

--- a/src/Authentication/README.md
+++ b/src/Authentication/README.md
@@ -20,7 +20,7 @@ var app = AzureArtifacts.CreateDefaultBuilder(authority)
 // Can use MsalTokenProviders which works for most cases, or compose the token providers manually
 var providers = MsalTokenProviders.Get(app, logger);
 
-var tokenRequest = new TokenRequest("https://pkgs.dev.azure.com/org")
+var tokenRequest = new TokenRequest
 {
     IsInteractive = true
 };


### PR DESCRIPTION
The build occurs in many phases and was relying on incremental builds not re-building outputs, which is not deterministic. Properties were not consistently passed at each step which results in outputs being flagged as out-of-date, causing rebuilds and loosing signing. These properties are now consistently passed, and --no-build used to ensure signed files are not overridden.