### PR TITLE
Adding pem certificate support for dotnet 6 or higher

### DIFF
--- a/CredentialProvider.Microsoft/Resources.resx
+++ b/CredentialProvider.Microsoft/Resources.resx
@@ -506,6 +506,12 @@ Provide MSAL Cache Location
   <data name="UsingCertificate" xml:space="preserve">
     <value>Using certificate: {0}.</value>
   </data>
+  <data name="ClientCertificateFileTypeNotSupported" xml:space="preserve">
+    <value>Certificate file type not supported. Only .pfx and .pem certificates are accepted.</value>
+  </data>
+  <data name="ClientCertificatePemFilesNotSupported" xml:space="preserve">
+    <value>Certificate file type .pem are only supported on versions of the credential provider built on .Net 6 or greater.</value>
+  </data>
   <data name="UsingTenant" xml:space="preserve">
     <value>Using Entra tenant: {0}.</value>
   </data>

--- a/CredentialProvider.Microsoft/Util/CertificateUtil.cs
+++ b/CredentialProvider.Microsoft/Util/CertificateUtil.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Security.Cryptography.X509Certificates;
 using ILogger = NuGetCredentialProvider.Logging.ILogger;
 
@@ -54,7 +55,22 @@ internal static class CertificateUtil
 
         try
         {
-            var certificate = new X509Certificate2(filePath);
+            var fileType = Path.GetExtension(filePath);
+            X509Certificate2 certificate;
+            switch (fileType)
+            {
+                case ".pfx":
+                    certificate = new X509Certificate2(filePath);
+                    break;
+                case ".pem":
+#if NET6_0_OR_GREATER
+                    certificate= X509Certificate2.CreateFromPemFile(filePath);
+                    break;
+#endif
+                    throw new NotSupportedException(Resources.ClientCertificatePemFilesNotSupported);
+                default:
+                    throw new NotSupportedException(Resources.ClientCertificateFileTypeNotSupported);
+            }
 
             if (certificate == null)
             {


### PR DESCRIPTION
Adding support for .pem certificates to address [artifacts-keyring issue](https://github.com/microsoft/artifacts-keyring/issues/60). Note this is only targeting .net 6 or greater versions of the cred provider, since the `CreateFromPemFile` is only available in .net 5 or greater. Otherwise, we have to implement reading the pem ourselves.

Additional Considerations:
- Add certificate passwords for pfx files.