### PR TITLE
Add .NET 8, FX 4.8.1 support

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>1.2.3</CredentialProviderVersion>
+    <CredentialProviderVersion>1.3.0</CredentialProviderVersion>
     <VersionSuffix></VersionSuffix>
-    <TargetFrameworks>netcoreapp3.1;net461;net6.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1;net461;net481;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,7 @@ In this and subsequent examples, configuration can be either `debug` or `release
 ### Publishing
 
 ```shell
-dotnet publish CredentialProvider.Microsoft --configuration Release --framework net6.0
+dotnet publish CredentialProvider.Microsoft --configuration Release --framework net8.0
 ```
 
 ### Packing

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.nuspec
@@ -18,7 +18,9 @@
     <file src="ThirdPartyNotices.txt" target="\" />
     <file src="EULA_Microsoft Visual Studio Team Services Credential Provider.docx" target="\" />
     <file src="bin\$Configuration$\net461\**\*.*" target="\plugins\netfx\CredentialProvider.Microsoft" />
+    <file src="bin\$Configuration$\net481\**\*.*" target="\plugins\netfx48\CredentialProvider.Microsoft" />
     <file src="bin\$Configuration$\netcoreapp3.1\publish\**\*.*" target="\plugins\netcore\CredentialProvider.Microsoft" />
     <file src="bin\$Configuration$\net6.0\publish\**\*.*" target="\plugins\net6.0\CredentialProvider.Microsoft" />
+    <file src="bin\$Configuration$\net8.0\publish\**\*.*" target="\plugins\net8.0\CredentialProvider.Microsoft" />
   </files>
 </package>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The Azure Artifacts Credential Provider automates the acquisition of credentials
 -   [Session Token Cache Locations](#session-token-cache-locations)
 -   [Environment Variables](#environment-variables)
 -   [Release version 1.0.0](#release-version-1.0.0)
+-   [Upcoming version 2.0.0](#release-version-2.0.0)
 -   [Help](#help)
 -   [Contribute](#contribute)
 
@@ -25,7 +26,7 @@ Install [Visual Studio version 15.9-preview1 or later](https://visualstudio.micr
 
 ### dotnet
 
-The default installation requires the [dotnet Runtime](https://www.microsoft.com/net/download) version `6.0.x` or later.
+The default installation requires the [dotnet runtime](https://www.microsoft.com/net/download) version `8.0.x` or later.
 
 ## Setup
 
@@ -163,6 +164,17 @@ The Credential Provider accepts a set of environment variables. Not all of them 
 Release version [1.0.0](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.0.0) was released in March 2022. Netcore version 1.0.0 of the Artifacts Credential Provider requires .NET Core 3.1. Older versions than 1.0.0 required .NET Core 2.1. `Microsoft.NetCore2.NuGet.CredentialProvider` asset is no longer available. Use  `Microsoft.NetCore3.NuGet.CredentialProvider.zip` instead.
 
 [1.0.0 release](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.0.0) also publishes the credential provider for .NET 6 users as `Microsoft.Net6.NuGet.CredentialProvider`.
+
+## Release version 2.0.0
+
+Release version 2.0.0 will be the next major version of artifacts-credprovider and will contain changes which end support for various .NET versions which have reached their end of support.
+
+- .NET Framework 4.6.1 (End of Support April 26, 2022) - Replaced with .NET Framework 4.8.1
+- .NET Core 3.1 (End of Support December 13, 2022) - Replaced with .NET 6/8
+
+After .NET 6 reaches its end of support on November 12, 2024 a minor version of artifacts-credprovider will be published to deprecate .NET 6 compatible binaries.
+
+- .NET 6 (End of Support November 12, 2024) - Replaced with .NET 8
 
 ## Help
 
@@ -305,12 +317,19 @@ Run the credential provider directly with the following command: `C:\Users\<user
 
 In an Azure DevOps Pipeline, verify you have set the right permissions for the pipeline by following the [docs](https://docs.microsoft.com/en-us/azure/devops/artifacts/feeds/feed-permissions?view=azure-devops#package-permissions-in-azure-pipelines).
 
-#### Cred provider used to work but now it asks me to update to .NET 6.0 or .NET Core 3.1.
-Because .NET Core 2 is [out of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle), you should update to .NET Core 3.1 or greater to keep using the latest versions of the credential provider.
+#### Cred provider used to work but now it asks me to update the .NET version.
+The .NET version installed is [out of support](https://dotnet.microsoft.com/platform/support/policy/dotnet-core#lifecycle), you should update to .NET 8.0 or greater to keep using the latest versions of the credential provider.
 
-> .NET Core 3.1 will also be removed from future versions. See the announcement [here](https://github.com/microsoft/artifacts-credprovider/discussions/386).
+> .NET Core 3.1 and .NET Framework 4.6.1 compatability will also be removed from major version 2.0.0. See the announcement [here](https://github.com/microsoft/artifacts-credprovider/discussions/386).
 
-If you keep using the unsupported .NET Core 2.1 you must use Artifacts Credential Provider version 0.1.28 or lower.
+To keep using .NET versions which are past their end of support date, see the table below for the maximum Artifacts Credential Provider version.
+
+| .NET Version | End of ACP Support |
+| -------- | ------- |
+| .NET Core 2.1 | 0.1.28 |
+| .NET Core 3.1 | 1.x.x (pending final release) |
+| .NET Framework 4.6.1 | 1.x.x (pending final release) |
+| .NET 6.0 | 2.x.x (pending release) |
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -167,12 +167,12 @@ Release version [1.0.0](https://github.com/microsoft/artifacts-credprovider/rele
 
 ## Release version 2.0.0
 
-Release version 2.0.0 will be the next major version of artifacts-credprovider and will contain changes which end support for various .NET versions which have reached their end of support.
+Release version 2.0.0 will be the next major version of artifacts-credprovider and will contain changes which end support for various .NET versions which have reached their end of support. It is planned for release in Q1 2025 to allow users to migrate their usage of the tool to the new .NET versions.
 
 - .NET Framework 4.6.1 (End of Support April 26, 2022) - Replaced with .NET Framework 4.8.1
 - .NET Core 3.1 (End of Support December 13, 2022) - Replaced with .NET 6/8
 
-After .NET 6 reaches its end of support on November 12, 2024 a minor version of artifacts-credprovider will be published to deprecate .NET 6 compatible binaries.
+.NET 6 will reach its end of support on November 12, 2024. After v2.0.0 is released, a minor version of artifacts-credprovider will be published to deprecate .NET 6 compatible binaries.
 
 - .NET 6 (End of Support November 12, 2024) - Replaced with .NET 8
 

--- a/build/build.yml
+++ b/build/build.yml
@@ -10,10 +10,16 @@ steps:
     version: 3.1.x
 
 - task: UseDotNet@2
-  displayName: Use .NET 6 SDK
+  displayName: Use .NET 6 runtime
+  inputs:
+    packageType: runtime
+    version: 6.x
+
+- task: UseDotNet@2
+  displayName: Use .NET 8 SDK
   inputs:
     packageType: sdk
-    version: 6.x
+    version: 8.x
 
 - task: NuGetToolInstaller@1
   displayName: NuGet Install
@@ -55,10 +61,10 @@ steps:
   - script: dotnet test MicrosoftCredentialProvider.sln --logger trx --results-directory $(Agent.TempDirectory)
     displayName: dotnet test
 
+# Create .NET 6.0 release for netcore users
 - script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework net6.0 --configuration $(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
   displayName: dotnet publish net6.0
 
-# Create .NET 6.0 release for netcore users
 - task: CopyFiles@2
   displayName: Copy net6.0 files into tarball
   inputs:
@@ -94,6 +100,47 @@ steps:
     includeRootFolder: false
     archiveType: 'zip'
     archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.Net6.NuGet.CredentialProvider.zip'
+    replaceExistingArchive: true
+
+# Clean target folder and create .NET 8.0 release for netcore users
+- script: dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --no-build --framework net8.0 --configuration $(BuildConfiguration) -p:${{ parameters.nuspecProperties }}
+  displayName: dotnet publish net8.0
+
+- task: CopyFiles@2
+  displayName: Copy net8.0 files into tarball
+  inputs:
+    sourceFolder: '$(Build.SourcesDirectory)\CredentialProvider.Microsoft\bin\$(BuildConfiguration)\net8.0\publish\'
+    contents: '**\*'
+    targetFolder: '$(Build.ArtifactStagingDirectory)\tarball\plugins\netcore\CredentialProvider.Microsoft\'
+    cleanTargetFolder: true
+
+- task: CopyFiles@2
+  displayName: Copy license files into tarball
+  inputs:
+    contents: |
+      LICENSE
+      CredentialProvider.Microsoft\EULA_Microsoft Visual Studio Team Services Credential Provider.docx
+      CredentialProvider.Microsoft\ThirdPartyNotices.txt
+    targetFolder: '$(Build.ArtifactStagingDirectory)\tarball\'
+    flattenFolders: true
+
+- task: ArchiveFiles@2
+  displayName: Create net8.0 tarball
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\tarball\'
+    includeRootFolder: false
+    archiveType: 'tar'
+    tarCompression: 'gz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.Net8.NuGet.CredentialProvider.tar.gz'
+    replaceExistingArchive: true
+
+- task: ArchiveFiles@2
+  displayName: Create net8.0 zip
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\tarball\'
+    includeRootFolder: false
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.Net8.NuGet.CredentialProvider.zip'
     replaceExistingArchive: true
 
 # Clean target folder and create netcore 3.1 and netfx releases
@@ -163,6 +210,32 @@ steps:
     includeRootFolder: false
     archiveType: 'zip'
     archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.NuGet.CredentialProvider.zip'
+    replaceExistingArchive: true
+
+- task: CopyFiles@2
+  displayName: Copy netfx 4.8.1 files into tarball
+  inputs:
+    sourceFolder: '$(Build.SourcesDirectory)\CredentialProvider.Microsoft\bin\$(BuildConfiguration)\net481\'
+    contents: '**\*'
+    targetFolder: '$(Build.ArtifactStagingDirectory)\tarball\plugins\netfx\CredentialProvider.Microsoft\'
+
+- task: ArchiveFiles@2
+  displayName: Create netfx 4.8.1 tarball
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\tarball\'
+    includeRootFolder: false
+    archiveType: 'tar'
+    tarCompression: 'gz'
+    archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.NetFx48.NuGet.CredentialProvider.tar.gz'
+    replaceExistingArchive: true
+
+- task: ArchiveFiles@2
+  displayName: Create netfx 4.8.1 zip
+  inputs:
+    rootFolderOrFile: '$(Build.ArtifactStagingDirectory)\tarball\'
+    includeRootFolder: false
+    archiveType: 'zip'
+    archiveFile: '$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\Microsoft.NetFx48.NuGet.CredentialProvider.zip'
     replaceExistingArchive: true
 
 - task: CopyFiles@2

--- a/build/build.yml
+++ b/build/build.yml
@@ -218,6 +218,7 @@ steps:
     sourceFolder: '$(Build.SourcesDirectory)\CredentialProvider.Microsoft\bin\$(BuildConfiguration)\net481\'
     contents: '**\*'
     targetFolder: '$(Build.ArtifactStagingDirectory)\tarball\plugins\netfx\CredentialProvider.Microsoft\'
+    cleanTargetFolder: true
 
 - task: ArchiveFiles@2
   displayName: Create netfx 4.8.1 tarball

--- a/test.bat
+++ b/test.bat
@@ -4,6 +4,11 @@ SETLOCAL EnableDelayedExpansion
 @REM A Windows domain user should be able to run this against a feed in an AAD-back AzDO org
 @REM and all scenarios should succeed non-interactively.
 
+IF "%~1" == "" (
+    echo "Please specify an AzDO organization package feed URL as the first parameter."
+    exit /b 1
+)
+
 set TEST_FEED=%1
 set NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_ENABLED=true
 set NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_LOCATION=%TEMP%\msal.cache
@@ -30,7 +35,7 @@ exit /b 0
 
 
 :TEST_FRAMEWORKS
-for %%I in ("netcoreapp3.1","net461","net6.0") DO (
+for %%I in ("netcoreapp3.1","net461","net481","net6.0","net8.0") DO (
     del /q "!UserProfile!\AppData\Local\MicrosoftCredentialProvider\*.dat" 2>NUL
     del /q "%NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_LOCATION%" 2>NUL
     echo Testing %%I with NUGET_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER=!NUGET_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER!


### PR DESCRIPTION
With the end of support for multiple .NET releases used by the artifacts credential provider, it's time to migrate to supported .NET versions. This includes a bump of .NET 6 -> .NET 8 and .NET Framework 4.6.1 to .NET Framework 4.8.1.

For more info on end of support dates, see https://github.com/dotnet/core/blob/main/releases.md

These new bits will not be set as the default version being installed until the next major release as documented in the README. I'll also post an announcement about the upcoming deprecation.