### PR TITLE
.NET 8 installcredprovider scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,11 @@ Dotnet needs the `netcore` version to be installed. NuGet and MSBuild need the `
 [PowerShell helper script](helpers/installcredprovider.ps1)
 - To install netcore, run `installcredprovider.ps1`
   - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) }"`
+  - .NET 6 bits can be installed using `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -InstallNet6"`
+  - .NET 8 bits can be installed using `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -InstallNet8"`
 - To install both netfx and netcore, run `installcredprovider.ps1 -AddNetfx`. The netfx version is needed for nuget.exe.
   - e.g. `iex "& { $(irm https://aka.ms/install-artifacts-credprovider.ps1) } -AddNetfx"`
+  - .NET Framework 4.8.1 support is available using the `-AddNetFx48` flag
 
 #### Manual installation on Windows
 
@@ -72,7 +75,7 @@ Examples:
 
 Using the above is recommended, but as per [NuGet's plugin discovery rules](https://github.com/NuGet/Home/wiki/NuGet-cross-plat-authentication-plugin#plugin-installation-and-discovery), alternatively you can install the credential provider to a location you prefer, and then set the environment variable NUGET_PLUGIN_PATHS to the .dll of the credential provider found in plugins\netcore\CredentialProvider.Microsoft\CredentialProvider.Microsoft.dll. For example, $env:NUGET_PLUGIN_PATHS="my-alternative-location\CredentialProvider.Microsoft.dll".
 
-Users requiring .NET 6, such as ARM64 users, can manually download the .NET 6 version `Microsoft.Net6.NuGet.CredentialProvider` of the [1.0.0 release](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.0.0).
+Users requiring .NET 6, such as ARM64 users, can manually download the .NET 6 version `Microsoft.Net6.NuGet.CredentialProvider` of the [1.0.0 release](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.0.0). Support for .NET 8 was added in [release 1.3.0](https://github.com/microsoft/artifacts-credprovider/releases/tag/v1.3.0) and can be downloaded with the `Microsoft.Net8.NuGet.CredentialProvider` archive.
 
 ### Automatic usage
 - MSBuild in Visual Studio Developer Command Prompt with Visual Studio 15.9+

--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -8,12 +8,16 @@
 param(
     # whether or not to install netfx folder for nuget
     [switch]$AddNetfx,
+    # whether or not to install netfx 4.8.1 folder for nuget
+    [switch]$AddNetfx48,
     # override existing cred provider with the latest version
     [switch]$Force,
     # install the version specified
     [string]$Version,
-    # install Net6 version of the netcore cred provider instead of NetCore3.1
-    [switch]$InstallNet6 = $true
+    # install the .NET 6 cred provider instead of NetCore3.1
+    [switch]$InstallNet6 = $true,
+    # install the .NET 8 cred provider instead of NetCore3.1
+    [switch]$InstallNet8
 )
 
 $script:ErrorActionPreference='Stop'
@@ -25,6 +29,19 @@ if ([Net.ServicePointManager]::SecurityProtocol.ToString().Split(',').Trim() -no
 
 if ($Version.StartsWith("0.") -and $InstallNet6 -eq $True) {
     Write-Error "You cannot install the .Net 6 version with versions lower than 1.0.0"
+    return
+}
+if (($Version.StartsWith("0.") -or $Version.StartsWith("1.0") -or $Version.StartsWith("1.1") -or $Version.StartsWith("1.2")) -and 
+    ($InstallNet8 -eq $True -or $AddNetfx48 -eq $True)) {
+    Write-Error "You cannot install the .Net 8 or NetFX 4.8.1 version or with versions lower than 1.3.0"
+    return
+}
+if ($AddNetfx -eq $True -and $AddNetfx48 -eq $True) {
+    Write-Error "Please select a single .Net framework version to install"
+    return
+}
+if ($InstallNet6 -eq $True -and $InstallNet8 -eq $True) {
+    Write-Error "Please select a single .Net core version to install"
     return
 }
 
@@ -94,8 +111,14 @@ if ($Version.StartsWith("0.")) {
 if ($InstallNet6 -eq $True) {
     $zipFile = "Microsoft.Net6.NuGet.CredentialProvider.zip"
 }
+if ($InstallNet8 -eq $True) {
+    $zipFile = "Microsoft.Net8.NuGet.CredentialProvider.zip"
+}
 if ($AddNetfx -eq $True) {
     $zipFile = "Microsoft.NuGet.CredentialProvider.zip"
+}
+if ($AddNetfx48 -eq $True) {
+    $zipFile = "Microsoft.NetFx48.NuGet.CredentialProvider.zip"
 }
 
 function InstallZip {
@@ -152,7 +175,7 @@ function InstallZip {
 InstallZip
 
 # Remove existing content and copy netfx directories to plugins directory
-if ($AddNetfx -eq $True) {
+if ($AddNetfx -eq $True -or $AddNetfx48 -eq $True) {
     if ($netfxExists) {
         Write-Verbose "Removing existing content from $fullNetfxCredProviderPath"
         Remove-Item $fullNetfxCredProviderPath -Force -Recurse
@@ -169,6 +192,12 @@ if ($AddNetfx -eq $True -and $InstallNet6 -eq $True) {
     Write-Verbose "Installing Net6"
     InstallZip
 }
+if ($AddNetfx -eq $True -and $InstallNet8 -eq $True) {
+    $zipFile = "Microsoft.Net8.NuGet.CredentialProvider.zip"
+    Write-Verbose "Installing Net8"
+    InstallZip
+}
+
 # Remove existing content and copy netcore directories to plugins directory
 if ($netcoreExists) {
     Write-Verbose "Removing existing content from $fullNetcoreCredProviderPath"

--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -41,8 +41,8 @@ if ($AddNetfx -eq $True -and $AddNetfx48 -eq $True) {
     return
 }
 if ($InstallNet6 -eq $True -and $InstallNet8 -eq $True) {
-    Write-Error "Please select a single .Net core version to install"
-    return
+    # InstallNet6 defaults to true, in the case of .Net 8 install, overwrite
+    $InstallNet6 = $False
 }
 
 $userProfilePath = [System.Environment]::GetFolderPath([System.Environment+SpecialFolder]::UserProfile);

--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -22,6 +22,16 @@ if [ -z ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET6_ARTIFACTS_CR
       exit 1
       ;;
   esac
+else if [ -z ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} != "false" ]; then
+  FILE="Microsoft.Net8.NuGet.CredentialProvider.tar.gz"
+
+  # throw if version starts < 1.3.0. (net8 not supported)
+  case ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} in 
+    0.*|v0.*|1.0.*|v1.0.*|1.1.*|v1.1.*|1.2.*|v1.2.*)
+      echo "ERROR: To install NET8 cred provider using the USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.3.0. or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
+      exit 1
+      ;;
+  esac
 else
   FILE="Microsoft.NuGet.CredentialProvider.tar.gz"
 fi

--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -18,7 +18,7 @@ if [ -z ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET6_ARTIFACTS_CR
   # throw if version starts with 0. (net6 not supported)
   case ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} in 
     0.*|v0.*)
-      echo "ERROR: To install NET6 cred provider using the USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.0.0. or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
+      echo "ERROR: To install NET6 cred provider using the USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.0.0 or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
       exit 1
       ;;
   esac
@@ -28,7 +28,7 @@ else if [ -z ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET8_ARTIFAC
   # throw if version starts < 1.3.0. (net8 not supported)
   case ${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION} in 
     0.*|v0.*|1.0.*|v1.0.*|1.1.*|v1.1.*|1.2.*|v1.2.*)
-      echo "ERROR: To install NET8 cred provider using the USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.3.0. or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
+      echo "ERROR: To install NET8 cred provider using the USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER variable, version to be installed must be 1.3.0 or greater. Check your AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION variable."
       exit 1
       ;;
   esac


### PR DESCRIPTION
Add support for the new .NET 8 and .NET Framework 4.8.1 versions in the `installcredprovider` command line scripts.

Invoke using the `$InstallNet8` or `$AddNetfx48` switch parameters for the `installcredprovider.ps1` script, or `USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER` for `installcredprovider.sh`