### PR TITLE
Fix typo in installcredprovider.sh

### DIFF
--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -22,7 +22,7 @@ if [ -z ${USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET6_ARTIFACTS_CR
       exit 1
       ;;
   esac
-else if [ -z ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} != "false" ]; then
+elif [ -z ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} ] || [ ${USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER} != "false" ]; then
   FILE="Microsoft.Net8.NuGet.CredentialProvider.tar.gz"
 
   # throw if version starts < 1.3.0. (net8 not supported)


### PR DESCRIPTION
Missed this commit in #524, adding it back now.