### PR TITLE
Add Comment to UserAgentHeader to specify if Self-Contained

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -27,6 +27,9 @@
     <Optimize>true</Optimize>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(RuntimeIdentifier)' != '' " >
+    <DefineConstants>$(DefineConstants);SELF_CONTAINED</DefineConstants>
+  </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" />

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -27,7 +27,7 @@
     <Optimize>true</Optimize>
     <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(RuntimeIdentifier)' != '' " >
+  <PropertyGroup Condition=" '$(SelfContained)' != '' " >
     <DefineConstants>$(DefineConstants);SELF_CONTAINED</DefineConstants>
   </PropertyGroup>
 

--- a/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
+++ b/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
@@ -43,10 +43,6 @@ public class MsalHttpClientFactoryTests
 
         var clrComment = userAgent.ElementAt(3);
         Assert.AreEqual(MsalHttpClientFactory.ClrComment, clrComment);
-#if SELF_CONTAINED
-        Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()}; {PlatformInformation.GetIsSelfContained()})", clrComment.Comment);
-#else
-        Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()})", clrComment.Comment);
-#endif
+        Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()}; self-contained={PlatformInformation.IsSelfContained()})", clrComment.Comment);
     }
 }

--- a/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
+++ b/src/Authentication.Tests/MsalHttpClientFactoryTests.cs
@@ -43,6 +43,10 @@ public class MsalHttpClientFactoryTests
 
         var clrComment = userAgent.ElementAt(3);
         Assert.AreEqual(MsalHttpClientFactory.ClrComment, clrComment);
+#if SELF_CONTAINED
+        Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()}; {PlatformInformation.GetIsSelfContained()})", clrComment.Comment);
+#else
         Assert.AreEqual($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()})", clrComment.Comment);
+#endif
     }
 }

--- a/src/Authentication/MsalHttpClientFactory.cs
+++ b/src/Authentication/MsalHttpClientFactory.cs
@@ -32,7 +32,7 @@ public class MsalHttpClientFactory : IMsalHttpClientFactory
         new ProductInfoHeaderValue("CLR", PlatformInformation.GetClrVersion());
 
     public static ProductInfoHeaderValue ClrComment =>
-        new ProductInfoHeaderValue($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()})");
+        new ProductInfoHeaderValue($"({PlatformInformation.GetClrFramework()}; {PlatformInformation.GetClrRuntime()}; {PlatformInformation.GetClrDescription()}; self-contained={PlatformInformation.IsSelfContained()})");
 
     // Produces a value similar to the following:
     // CredentialProvider.Microsoft/1.0.4+aae4981de95d543b7935811c05474e393dd9e144 (Windows; X64; Microsoft Windows 10.0.19045) CLR/6.0.16 (.NETCoreApp,Version=v6.0; win10-x64; .NET 6.0.16)

--- a/src/Authentication/PlatformInformation.cs
+++ b/src/Authentication/PlatformInformation.cs
@@ -79,4 +79,12 @@ public static class PlatformInformation
     {
         return RuntimeInformation.FrameworkDescription;
     }
+
+    public static bool IsSelfContained(){
+#if SELF_CONTAINED
+        return true;
+#else
+        return false;
+#endif
+    }
 }


### PR DESCRIPTION
In order to prepare for publishing the artifacts-credprovider as a self-contained application, this pull request adds a comment to the UserAgentHeader to track if the application is self-contained for reporting and debugging purposes. 
- the CLR comment already specifies which RID is used. 
- updated unit tests
