### PR TITLE
add install script validation to build pipeline

### DIFF
--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -13,6 +13,7 @@ variables:
 
 stages:
 - stage: Build
+  dependsOn: [] 
   jobs:
   - job: build
     steps:
@@ -21,6 +22,7 @@ stages:
         nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
 
 - stage: ValidateInstallScriptWindows
+  dependsOn: [] 
   pool:
     vmImage: windows-latest
   jobs:
@@ -29,6 +31,7 @@ stages:
       repo: 'self'
 
 - stage: ValidateInstallScriptLinux
+  dependsOn: [] 
   pool:
     vmImage: ubuntu-latest
   jobs:

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -11,17 +11,27 @@ variables:
   BuildConfiguration: 'Release'
   TeamName: 'Package Experience'
 
-jobs:
-- job: build
-  steps:
-  - template: build/build.yml
+stages:
+- stage: Build
+  jobs:
+  - job: build
+    steps:
+    - template: build/build.yml
+      parameters:
+        nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
+
+- stage: ValidateInstallScriptWindows
+  pool:
+    vmImage: windows-latest
+  jobs:
+  - template: build/validate-install-script-ps.yml
     parameters:
-      nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
-- template: build/validate-install-script-ps.yml
-  parameters:
-    pool: 'windows-latest'
-    repo: 'self'
-- template: build/validate-install-script-sh.yml
-  parameters:
-    pool: 'ubuntu-latest'
-    repo: 'self'
+      repo: 'self'
+
+- stage: ValidateInstallScriptLinux
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
+  - template: build/validate-install-script-sh.yml
+    parameters:
+      repo: 'self'  

--- a/.vsts-ci.yml
+++ b/.vsts-ci.yml
@@ -11,7 +11,17 @@ variables:
   BuildConfiguration: 'Release'
   TeamName: 'Package Experience'
 
-steps:
-- template: build/build.yml
+jobs:
+- job: build
+  steps:
+  - template: build/build.yml
+    parameters:
+      nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
+- template: build/validate-install-script-ps.yml
   parameters:
-    nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
+    pool: 'windows-latest'
+    repo: 'self'
+- template: build/validate-install-script-sh.yml
+  parameters:
+    pool: 'ubuntu-latest'
+    repo: 'self'

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -21,11 +21,12 @@ stages:
         nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
 
 - stage: ValidateInstallScript
-- template: build/validate-install-script-ps.yml
-  parameters:
-    pool: 'windows-latest'
-    repo: 'self'
-- template: build/validate-install-script-sh.yml
-  parameters:
-    pool: 'ubuntu-latest'
-    repo: 'self'  
+  jobs:
+  - template: build/validate-install-script-ps.yml
+    parameters:
+      pool: 'windows-latest'
+      repo: 'self'
+  - template: build/validate-install-script-sh.yml
+    parameters:
+      pool: 'ubuntu-latest'
+      repo: 'self'  

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -11,17 +11,21 @@ variables:
   BuildConfiguration: 'Debug'
   TeamName: 'Package Experience'
 
-jobs:
-- job: build
-  steps:
-  - template: build/build.yml
+stages:
+- stage: Build
+  jobs:
+  - job: build
+    steps:
+    - template: build/build.yml
+      parameters:
+        nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
+
+- stage: ValidateInstallScript
+  - template: build/validate-install-script-ps.yml
     parameters:
-      nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
-- template: build/validate-install-script-ps.yml
-  parameters:
-    pool: 'windows-latest'
-    repo: 'self'
-- template: build/validate-install-script-sh.yml
-  parameters:
-    pool: 'ubuntu-latest'
-    repo: 'self'
+      pool: 'windows-latest'
+      repo: 'self'
+  - template: build/validate-install-script-sh.yml
+    parameters:
+      pool: 'ubuntu-latest'
+      repo: 'self'  

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -13,6 +13,7 @@ variables:
 
 stages:
 - stage: Build
+  dependsOn: [] 
   jobs:
   - job: build
     steps:
@@ -21,6 +22,7 @@ stages:
         nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
 
 - stage: ValidateInstallScriptWindows
+  dependsOn: [] 
   pool:
     vmImage: windows-latest
   jobs:
@@ -29,6 +31,7 @@ stages:
       repo: 'self'
 
 - stage: ValidateInstallScriptLinux
+  dependsOn: [] 
   pool:
     vmImage: ubuntu-latest
   jobs:

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -11,7 +11,17 @@ variables:
   BuildConfiguration: 'Debug'
   TeamName: 'Package Experience'
 
-steps:
-- template: build/build.yml
+jobs:
+- job: build
+  steps:
+  - template: build/build.yml
+    parameters:
+      nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
+- template: build/validate-install-script-ps.yml
   parameters:
-    nuspecProperties: 'VersionSuffix=PR-$(Build.BuildNumber)'
+    pool: 'windows-latest'
+    repo: 'self'
+- template: build/validate-install-script-sh.yml
+  parameters:
+    pool: 'ubuntu-latest'
+    repo: 'self'

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -24,9 +24,9 @@ stages:
   jobs:
   - template: build/validate-install-script-ps.yml
     parameters:
-      pool: 'windows-latest'
+      image: 'windows-latest'
       repo: 'self'
   - template: build/validate-install-script-sh.yml
     parameters:
-      pool: 'ubuntu-latest'
+      image: 'ubuntu-latest'
       repo: 'self'  

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -21,11 +21,11 @@ stages:
         nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
 
 - stage: ValidateInstallScript
-  - template: build/validate-install-script-ps.yml
-    parameters:
-      pool: 'windows-latest'
-      repo: 'self'
-  - template: build/validate-install-script-sh.yml
-    parameters:
-      pool: 'ubuntu-latest'
-      repo: 'self'  
+- template: build/validate-install-script-ps.yml
+  parameters:
+    pool: 'windows-latest'
+    repo: 'self'
+- template: build/validate-install-script-sh.yml
+  parameters:
+    pool: 'ubuntu-latest'
+    repo: 'self'  

--- a/.vsts-pr.yml
+++ b/.vsts-pr.yml
@@ -20,13 +20,18 @@ stages:
       parameters:
         nuspecProperties: 'VersionSuffix=CI-$(Build.BuildNumber)'
 
-- stage: ValidateInstallScript
+- stage: ValidateInstallScriptWindows
+  pool:
+    vmImage: windows-latest
   jobs:
   - template: build/validate-install-script-ps.yml
     parameters:
-      image: 'windows-latest'
       repo: 'self'
+
+- stage: ValidateInstallScriptLinux
+  pool:
+    vmImage: ubuntu-latest
+  jobs:
   - template: build/validate-install-script-sh.yml
     parameters:
-      image: 'ubuntu-latest'
       repo: 'self'  

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -1,12 +1,17 @@
 parameters:
 - name: pool
   type: string
+  default: ''
+- name: image
+  type: string
 - name: repo
   type: string
+
 
 jobs:
 - job: WindowsInstallDefault
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -19,6 +24,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNet8
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -31,6 +37,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfxDefault
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -43,6 +50,7 @@ jobs:
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfx48
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -1,17 +1,9 @@
 parameters:
-- name: pool
-  type: string
-  default: ''
-- name: image
-  type: string
 - name: repo
   type: string
 
-
 jobs:
 - job: WindowsInstallDefault
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -23,8 +15,6 @@ jobs:
         if( (Select-String -Path .\output.log -Pattern "Microsoft.Net6.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNet8
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -36,8 +26,6 @@ jobs:
         if( (Select-String -Path .\output.log -Pattern "Microsoft.Net8.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfxDefault
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -49,8 +37,6 @@ jobs:
         if( (Select-String -Path .\output.log -Pattern "Microsoft.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfx48
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -4,9 +4,8 @@ parameters:
 - name: repo
   type: string
 
-jobs:
-pool: ${{ parameters.pool }}
 - job: WindowsInstallDefault
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -18,6 +17,7 @@ pool: ${{ parameters.pool }}
         if( (Select-String -Path .\output.log -Pattern "Microsoft.Net6.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNet8
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -29,6 +29,7 @@ pool: ${{ parameters.pool }}
         if( (Select-String -Path .\output.log -Pattern "Microsoft.Net8.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfxDefault
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
@@ -40,6 +41,7 @@ pool: ${{ parameters.pool }}
         if( (Select-String -Path .\output.log -Pattern "Microsoft.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfx48
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -7,43 +7,47 @@ jobs:
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
+    displayName: Validate Install Script
     inputs:
       targetType: 'inline'
       script: |
         ./helpers/installcredprovider.ps1 -Force 6>> ./output.log
         cat ./output.log
-        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net6.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net6.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider file not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNet8
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
+    displayName: Validate Install Script
     inputs:
       targetType: 'inline'
       script: |
         ./helpers/installcredprovider.ps1 -InstallNet8 -Force 6>> ./output.log
         cat ./output.log
-        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net8.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net8.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider file not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfxDefault
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
+    displayName: Validate Install Script
     inputs:
       targetType: 'inline'
       script: |
         ./helpers/installcredprovider.ps1 -AddNetfx -Force 6>> ./output.log
         cat ./output.log
-        if( (Select-String -Path .\output.log -Pattern "Microsoft.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider file not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)
 - job: WindowsInstallNetfx48
   steps:
   - checkout: ${{ parameters.repo }}
   - task: PowerShell@2
+    displayName: Validate Install Script
     inputs:
       targetType: 'inline'
       script: |
         ./helpers/installcredprovider.ps1 -AddNetFx48 -Force 6>> ./output.log
         cat ./output.log
-        if((Select-String -Path .\output.log -Pattern "Microsoft.NetFx48.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+        if((Select-String -Path .\output.log -Pattern "Microsoft.NetFx48.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider file not found."; exit 1}
       workingDirectory: $(Build.SourcesDirectory)

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -4,6 +4,7 @@ parameters:
 - name: repo
   type: string
 
+jobs:
 - job: WindowsInstallDefault
   pool: ${{ parameters.pool }}
   steps:

--- a/build/validate-install-script-ps.yml
+++ b/build/validate-install-script-ps.yml
@@ -1,0 +1,52 @@
+parameters:
+- name: pool
+  type: string
+- name: repo
+  type: string
+
+jobs:
+pool: ${{ parameters.pool }}
+- job: WindowsInstallDefault
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        ./helpers/installcredprovider.ps1 -Force 6>> ./output.log
+        cat ./output.log
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net6.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+      workingDirectory: $(Build.SourcesDirectory)
+- job: WindowsInstallNet8
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        ./helpers/installcredprovider.ps1 -InstallNet8 -Force 6>> ./output.log
+        cat ./output.log
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.Net8.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+      workingDirectory: $(Build.SourcesDirectory)
+- job: WindowsInstallNetfxDefault
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        ./helpers/installcredprovider.ps1 -AddNetfx -Force 6>> ./output.log
+        cat ./output.log
+        if( (Select-String -Path .\output.log -Pattern "Microsoft.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+      workingDirectory: $(Build.SourcesDirectory)
+- job: WindowsInstallNetfx48
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - task: PowerShell@2
+    inputs:
+      targetType: 'inline'
+      script: |
+        ./helpers/installcredprovider.ps1 -AddNetFx48 -Force 6>> ./output.log
+        cat ./output.log
+        if((Select-String -Path .\output.log -Pattern "Microsoft.NetFx48.NuGet.CredentialProvider") -eq $null) {echo "Expected credential provider ile not found."; exit 1}
+      workingDirectory: $(Build.SourcesDirectory)

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -4,6 +4,7 @@ parameters:
 - name: repo
   type: string
 
+jobs:
 - job: validateLineEndings
   pool: ${{ parameters.pool }}
   steps:

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -1,24 +1,15 @@
 parameters:
-- name: pool
-  type: string
-  default: ''
-- name: image
-  type: string
 - name: repo
   type: string
 
 jobs:
 - job: validateLineEndings
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: |
       if [grep $'\r' ./helpers/installcredprovider.sh]; then echo "CRLF line ending found" ; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallDefault
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 
@@ -28,8 +19,6 @@ jobs:
       if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallNet8
-  pool: ${{ parameters.pool }}
-    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -1,12 +1,16 @@
 parameters:
 - name: pool
   type: string
+  default: ''
+- name: image
+  type: string
 - name: repo
   type: string
 
 jobs:
 - job: validateLineEndings
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: |
@@ -14,6 +18,7 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallDefault
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 
@@ -24,6 +29,7 @@ jobs:
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallNet8
   pool: ${{ parameters.pool }}
+    vmImage: ${{ parameters.image }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -1,0 +1,36 @@
+parameters:
+- name: pool
+  type: string
+- name: repo
+  type: string
+
+jobs:
+pool: ${{ parameters.pool }}
+- job: validateLineEndings
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - bash: |
+      if [grep $'\r' ./helpers/installcredprovider.sh]; then echo "CRLF line ending found" ; exit 1; fi
+    workingDirectory: $(Build.SourcesDirectory)
+- job: LinuxInstallDefault
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - bash: | 
+      ./helpers/installcredprovider.sh -Force >> ./output.log
+      cat ./output.log
+      if [! grep "Microsoft.Net6.NuGet.CredentialProvider" ./output.log]; then echo "Not found"; exit 1; fi
+      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
+    workingDirectory: $(Build.SourcesDirectory)
+- job: LinuxInstallNet8
+  steps:
+  - checkout: ${{ parameters.repo }}
+  - bash: | 
+      export USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER=false
+      export USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER=true
+
+      ./helpers/installcredprovider.sh -Force >> ./output.log
+      cat ./output.log
+      if [! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log]; then echo "wrong version"; exit 1; fi
+      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
+    workingDirectory: $(Build.SourcesDirectory)
+  

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -16,8 +16,17 @@ jobs:
   - bash: | 
       ./helpers/installcredprovider.sh -Force >> ./output.log
       cat ./output.log
-      if [! grep "Microsoft.Net6.NuGet.CredentialProvider" ./output.log]; then echo "Expected credential provider not found"; exit 1; fi
-      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Credential provider plugin directory not found"; exit 1; fi
+
+      if ! grep "Microsoft.Net6.NuGet.CredentialProvider" ./output.log; then
+        echo "Expected credential provider not found"
+        exit 1
+      fi
+      if [ ! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft" ]; then
+        echo "Credential provider plugin directory not found"
+        exit 1
+      fi
+      
+      echo "Credential provider installed successfully"
     workingDirectory: $(Build.SourcesDirectory)
     displayName: Validate Install Script
 - job: LinuxInstallNet8
@@ -26,11 +35,19 @@ jobs:
   - bash: | 
       export USE_NET6_ARTIFACTS_CREDENTIAL_PROVIDER=false
       export USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER=true
-
       ./helpers/installcredprovider.sh -Force >> ./output.log
       cat ./output.log
-      if [! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log]; then echo "Expected credential provider not found"; exit 1; fi
-      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Credential provider plugin directory not found"; exit 1; fi
+      
+      if ! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log; then
+        echo "Expected credential provider not found"
+        exit 1
+      fi
+      if [ ! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft" ]; then
+        echo "Credential provider plugin directory not found"
+        exit 1
+      fi
+
+      echo "Credential provider installed successfully"
     workingDirectory: $(Build.SourcesDirectory)
     displayName: Validate Install Script
   

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -7,7 +7,10 @@ jobs:
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: |
-      if [grep $'\r' ./helpers/installcredprovider.sh]; then echo "CRLF line ending found" ; exit 1; fi
+      if grep $'\r' ./helpers/installcredprovider.sh; then e
+        echo "CRLF line ending found"
+        exit 1
+      fi
     workingDirectory: $(Build.SourcesDirectory)
     displayName: Validate Install Script
 - job: LinuxInstallDefault
@@ -37,7 +40,7 @@ jobs:
       export USE_NET8_ARTIFACTS_CREDENTIAL_PROVIDER=true
       ./helpers/installcredprovider.sh -Force >> ./output.log
       cat ./output.log
-      
+
       if ! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log; then
         echo "Expected credential provider not found"
         exit 1

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -9,15 +9,17 @@ jobs:
   - bash: |
       if [grep $'\r' ./helpers/installcredprovider.sh]; then echo "CRLF line ending found" ; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
+    displayName: Validate Install Script
 - job: LinuxInstallDefault
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 
       ./helpers/installcredprovider.sh -Force >> ./output.log
       cat ./output.log
-      if [! grep "Microsoft.Net6.NuGet.CredentialProvider" ./output.log]; then echo "Not found"; exit 1; fi
-      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
+      if [! grep "Microsoft.Net6.NuGet.CredentialProvider" ./output.log]; then echo "Expected credential provider not found"; exit 1; fi
+      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Credential provider plugin directory not found"; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
+    displayName: Validate Install Script
 - job: LinuxInstallNet8
   steps:
   - checkout: ${{ parameters.repo }}
@@ -27,7 +29,8 @@ jobs:
 
       ./helpers/installcredprovider.sh -Force >> ./output.log
       cat ./output.log
-      if [! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log]; then echo "wrong version"; exit 1; fi
-      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
+      if [! grep "Microsoft.Net8.NuGet.CredentialProvider" ./output.log]; then echo "Expected credential provider not found"; exit 1; fi
+      if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Credential provider plugin directory not found"; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
+    displayName: Validate Install Script
   

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -7,7 +7,7 @@ jobs:
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: |
-      if grep $'\r' ./helpers/installcredprovider.sh; then e
+      if grep $'\r' ./helpers/installcredprovider.sh; then 
         echo "CRLF line ending found"
         exit 1
       fi

--- a/build/validate-install-script-sh.yml
+++ b/build/validate-install-script-sh.yml
@@ -4,15 +4,15 @@ parameters:
 - name: repo
   type: string
 
-jobs:
-pool: ${{ parameters.pool }}
 - job: validateLineEndings
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: |
       if [grep $'\r' ./helpers/installcredprovider.sh]; then echo "CRLF line ending found" ; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallDefault
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 
@@ -22,6 +22,7 @@ pool: ${{ parameters.pool }}
       if [! -d "$HOME/.nuget/plugins/netcore/CredentialProvider.Microsoft"]; then echo "Not found"; exit 1; fi
     workingDirectory: $(Build.SourcesDirectory)
 - job: LinuxInstallNet8
+  pool: ${{ parameters.pool }}
   steps:
   - checkout: ${{ parameters.repo }}
   - bash: | 


### PR DESCRIPTION
- Add initial validation for our install scripts
    - Currently depending on log output for expected installed file validation.
    - Checking installation directory existence.
    - Not checking actual install file dotnet dependency.
- Update pr/ci pipelines to run validation with build stage