### PR TITLE
Conditionally Override TargetFrameworks

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -5,4 +5,8 @@
     <VersionSuffix></VersionSuffix>
     <TargetFrameworks>netcoreapp3.1;net461;net481;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>
+  <!-- Remove with netcoreapp3.1; required for self-contained build -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
Conditionally override target frameworks for self-contained runtimes not supported by earlier dotnet core versions.

Error packaging osx-arm64 with dotnet3.1:

```
dotnet publish CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj --framework net8.0 --self-contained true --runtime osx-arm64

error NETSDK1084: There is no application host available for the specified RuntimeIdentifier 'osx-arm64'. [/mnt/vss/_work/1/s/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj::TargetFramework=netcoreapp3.1]
```

Even with --framework dotnet parameter and passing the -p:TargetFrameworks breaks netstandard2.0 library build

