### PR TITLE
Broker: Add ability to pass parent window handle explicitly for Windows broker auth (org pr from seclerp)

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/Vsts/MsalTokenProvidersFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/Vsts/MsalTokenProvidersFactory.cs
@@ -30,7 +30,7 @@ namespace NuGetCredentialProvider.CredentialProviders.Vsts
             }
 
             var app = AzureArtifacts.CreateDefaultBuilder(authority)
-                .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), logger)
+                .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), EnvUtil.GetMsalBrokerWindowHandle(), logger)
                 .WithHttpClientFactory(HttpClientFactory.Default)
                 .WithLogging(
                     (Microsoft.Identity.Client.LogLevel level, string message, bool containsPii) =>

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
@@ -24,7 +24,7 @@ internal class VstsBuildTaskMsalTokenProvidersFactory : ITokenProvidersFactory
     public Task<IEnumerable<ITokenProvider>> GetAsync(Uri authority)
     {
         var app = AzureArtifacts.CreateDefaultBuilder(authority)
-            .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), logger)
+            .WithBroker(EnvUtil.MsalAllowBrokerEnabled(), EnvUtil.GetMsalBrokerWindowHandle(), logger)
             .WithHttpClientFactory(HttpClientFactory.Default)
             .WithLogging(
                 (level, message, containsPii) =>

--- a/CredentialProvider.Microsoft/Util/EnvUtil.cs
+++ b/CredentialProvider.Microsoft/Util/EnvUtil.cs
@@ -35,6 +35,7 @@ namespace NuGetCredentialProvider.Util
         public const string MsalFileCacheEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_ENABLED";
         public const string MsalFileCacheLocationEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_FILECACHE_LOCATION";
         public const string MsalAllowBrokerEnvVar = "NUGET_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER";
+        public const string MsalBrokerWindowEnvVar = "ARTIFACTS_CREDENTIALPROVIDER_MSAL_BROKER_WINDOW";
 
         public const string EndpointCredentials = "ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS";
         public const string BuildTaskExternalEndpoints = "VSS_NUGET_EXTERNAL_FEED_ENDPOINTS";
@@ -100,6 +101,22 @@ namespace NuGetCredentialProvider.Util
         public static bool MsalAllowBrokerEnabled()
         {
             return GetEnabledFromEnvironment(MsalAllowBrokerEnvVar, defaultValue: RuntimeInformation.IsOSPlatform(OSPlatform.Windows));
+        }
+
+        public static IntPtr? GetMsalBrokerWindowHandle()
+        {
+            var handleRaw = Environment.GetEnvironmentVariable(MsalBrokerWindowEnvVar);
+            if (handleRaw == null)
+            {
+                return null;
+            }
+
+            if (!long.TryParse(handleRaw, out var numericHandle))
+            {
+                return null;
+            }
+
+            return new IntPtr(numericHandle);
         }
 
         public static IList<string> GetHostsFromEnvironment(ILogger logger, string envVar, IEnumerable<string> defaultHosts, [CallerMemberName] string collectionName = null)

--- a/src/Authentication/AzureArtifacts.cs
+++ b/src/Authentication/AzureArtifacts.cs
@@ -33,7 +33,7 @@ public static class AzureArtifacts
         return builder;
     }
 
-    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, ILogger logger)
+    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, IntPtr? parentWindowHandle, ILogger logger)
     {
         // Eventually will be rolled into CreateDefaultBuilder as using the brokers is desirable
         if (!enableBroker || !RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
@@ -51,7 +51,12 @@ public static class AzureArtifacts
                     ListOperatingSystemAccounts = true,
                     MsaPassthrough = true
                 })
-            .WithParentActivityOrWindow(() => GetConsoleOrTerminalWindow());
+            .WithParentActivityOrWindow(() => parentWindowHandle ?? GetConsoleOrTerminalWindow());
+    }
+
+    public static PublicClientApplicationBuilder WithBroker(this PublicClientApplicationBuilder builder, bool enableBroker, ILogger logger)
+    {
+        return builder.WithBroker(enableBroker, null, logger);
     }
 
     public static PublicClientApplicationBuilder WithHttpClient(this PublicClientApplicationBuilder builder, HttpClient? httpClient = null)


### PR DESCRIPTION
This change was originally created by seclerp, but since then it was abandoned. I am re-creating here the same changes.