### PR TITLE
Prepare 1.4.1 Release

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>1.4.0</CredentialProviderVersion>
+    <CredentialProviderVersion>1.4.1</CredentialProviderVersion>
     <VersionSuffix></VersionSuffix>
     <TargetFrameworks>netcoreapp3.1;net461;net481;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
- Bump credprovider version to prepare for 1.4.1 release (Fdf2097fL1R1)
- Add npm context
- Fix release pipeline osx self-contained signing errors
- Update install scripts to support single RID parameters
- Update ReferenceTrimmer to 3.3.11