### PR TITLE
Show download exception message for ps1 helper

### DIFF
--- a/helpers/installcredprovider.ps1
+++ b/helpers/installcredprovider.ps1
@@ -207,7 +207,11 @@ function InstallZip {
         $client.DownloadFile($packageSourceUrl, $pluginZip)
     }
     catch {
-        Write-Error "Unable to download $packageSourceUrl to the location $pluginZip. `n$_"
+        $errorMessage = "Unable to download $packageSourceUrl to the location $pluginZip. `n$_"
+        if ($_.Exception.InnerException) {
+            $errorMessage += "`nInner Exception: $($_.Exception.InnerException.Message)"
+        }
+        Write-Error $errorMessage
     }
 
     # Extract zip to temp directory


### PR DESCRIPTION
Output example:
```
Unable to download https://github.com/microsoft/artifacts-credprovider/releases/download/v1.4.1/Microsoft.Net6.NuGet.CredentialProvider.zip to the location /tmp/CredProviderZip/Microsoft.Net6.NuGet.CredentialProvider.zip.
Exception calling "DownloadFile" with "2" argument(s): "The SSL connection could not be established, see inner exception."
Inner Exception 1: The SSL connection could not be established, see inner exception.
Inner Exception 2: The SSL connection could not be established, see inner exception.
Inner Exception 3: The remote certificate is invalid because of errors in the certificate chain: PartialChain
```