### PR TITLE
Add net8 targetframework to PackAsTool build.props

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -10,4 +10,8 @@
   <PropertyGroup Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
     <TargetFrameworks>net8.0</TargetFrameworks>
   </PropertyGroup>
+
+  <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
+    <TargetFrameworks>net8.0</TargetFrameworks>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
- specify framework in build props for dotnet tool 