### PR TITLE
Fix swix plugin path build

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swixproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swixproj
@@ -19,7 +19,7 @@
   <PropertyGroup>
     <OutputPath>.\bin\$(Configuration)\</OutputPath>
     <OutDir>$(OutputPath)</OutDir>
-    <PluginBinPath>..\CredentialProvider.Microsoft\bin\$(Configuration)\net481\</PluginBinPath>
+    <PluginBinPath>..\CredentialProvider.Microsoft\bin\$(Configuration)\net481</PluginBinPath>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Remove trailing / from PluginBinPath to prevent `\\` during .swr file source resolution resulting in file not found error.
