### PR TITLE
Clean up DLL references in CredentialProvider.swr

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swr
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.swr
@@ -28,14 +28,11 @@ folder InstallDir:\Common7\IDE\CommonExtensions\Microsoft\NuGet\Plugins\Credenti
   file source=$(PluginBinPath)\NuGet.Versioning.dll
   file source=$(PluginBinPath)\PowerArgs.dll
   file source=$(PluginBinPath)\System.Buffers.dll
-  file source=$(PluginBinPath)\System.Collections.NonGeneric.dll
-  file source=$(PluginBinPath)\System.ComponentModel.dll
   file source=$(PluginBinPath)\System.Diagnostics.DiagnosticSource.dll
   file source=$(PluginBinPath)\System.IO.FileSystem.AccessControl.dll
   file source=$(PluginBinPath)\System.Memory.dll
   file source=$(PluginBinPath)\System.Numerics.Vectors.dll
   file source=$(PluginBinPath)\System.Runtime.CompilerServices.Unsafe.dll
-  file source=$(PluginBinPath)\System.Runtime.CompilerServices.VisualC.dll
   file source=$(PluginBinPath)\System.Security.AccessControl.dll
   file source=$(PluginBinPath)\System.Security.Cryptography.ProtectedData.dll
   file source=$(PluginBinPath)\System.Security.Principal.Windows.dll


### PR DESCRIPTION
Removed several unused DLL references and added System.IO.FileSystem.AccessControl.dll and System.Security.Principal.Windows.dll.