### PR TITLE
Service principal authentication with client secret

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -101,7 +101,8 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                     InteractiveTimeout = TimeSpan.FromSeconds(EnvUtil.GetDeviceFlowTimeoutFromEnvironmentInSeconds(Logger)),
                     ClientId = matchingEndpoint.ClientId,
                     ClientCertificate = clientCertificate,
-                    TenantId = authInfo.EntraTenantId
+                    TenantId = authInfo.EntraTenantId,
+                    ClientSecret = !string.IsNullOrEmpty(matchingEndpoint.ClientSecret) ? new(matchingEndpoint.ClientSecret) : null,
                 };
 
                 foreach(var tokenProvider in tokenProviders)

--- a/CredentialProvider.Microsoft/Util/FeedEndpointCredentialsParser.cs
+++ b/CredentialProvider.Microsoft/Util/FeedEndpointCredentialsParser.cs
@@ -32,6 +32,8 @@ public class EndpointCredentials
     public string CertificateFilePath { get; set; }
     [JsonPropertyName("clientCertificateSubjectName")]
     public string CertificateSubjectName { get; set; }
+    [JsonPropertyName("clientSecret")]
+    public string ClientSecret { get; set; }
 }
 
 public class EndpointCredentialsContainer
@@ -72,25 +74,25 @@ public static class FeedEndpointCredentialsParser
                 if (credentials == null)
                 {
                     logger.Verbose(Resources.EndpointParseFailure);
-                    break;
+                    continue;
                 }
 
                 if (credentials.ClientId == null)
                 {
                     logger.Verbose(Resources.EndpointParseFailure);
-                    break;
+                    continue;
                 }
 
                 if (credentials.CertificateSubjectName != null && credentials.CertificateFilePath != null)
                 {
                     logger.Verbose(Resources.EndpointParseFailure);
-                    break;
+                    continue;
                 }
 
                 if (!Uri.TryCreate(credentials.Endpoint, UriKind.Absolute, out var endpointUri))
                 {
                     logger.Verbose(Resources.EndpointParseFailure);
-                    break;
+                    continue;
                 }
 
                 var urlEncodedEndpoint = endpointUri.AbsoluteUri;
@@ -105,7 +107,7 @@ public static class FeedEndpointCredentialsParser
         catch (Exception ex)
         {
             logger.Verbose(string.Format(Resources.VstsBuildTaskExternalCredentialCredentialProviderError, ex));
-            return new Dictionary<string, EndpointCredentials>(StringComparer.OrdinalIgnoreCase); ;
+            return new Dictionary<string, EndpointCredentials>(StringComparer.OrdinalIgnoreCase);
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -157,13 +157,14 @@ The Credential Provider accepts a set of environment variables. Not all of them 
 
 -   `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS`: Json that contains an array of endpoints, usernames and azure service principal information needed to authenticate to Azure Artifacts feed endponts. Example:
     ```javascript
-    {"endpointCredentials": [{"endpoint":"http://example.index.json", "clientId":"required", "clientCertificateSubjectName":"optional", "clientCertificateFilePath":"optional"}]}
+    {"endpointCredentials": [{"endpoint":"http://example.index.json", "clientId":"required", "clientCertificateSubjectName":"optional", "clientCertificateFilePath":"optional", "clientSecret":"optional"}]}
     ```
 
     - `endpoint`: Required. Feed url to authenticate.
     - `clientId`: Required for both Azure Managed Identites and Service Principals. For user assigned managed identities enter the Entra client id. For system assigned managed identities set the value to `system`.
     - `clientCertificateSubjectName`: Subject Name of the certificate located in the CurrentUser or LocalMachine certificate store. Optional field. Only used for service principal authentication.
-    - `clientCertificateFilePath`: File path location of the certificate on the machine. Optional field. Only used by service principal authentication. 
+    - `clientCertificateFilePath`: File path location of the certificate on the machine. Optional field. Only used by service principal authentication.
+    - `clientSecret`: Client secret used for service principal authentication. Optional field. Only used for sevice principal authentication if client certificate is not specified. Prefer using a certificate for improved security.
 
 ## Release version 1.0.0
 

--- a/src/Authentication/TokenRequest.cs
+++ b/src/Authentication/TokenRequest.cs
@@ -40,4 +40,14 @@ public class TokenRequest
     public string? TenantId { get; set; } = null;
 
     public X509Certificate2? ClientCertificate { get; set; } = null;
+
+    public ClientSecret? ClientSecret { get; set; } = null;
+}
+
+/// <summary>
+/// Wraps a client secret string to avoid accidental logging.
+/// </summary>
+public class ClientSecret(string secret)
+{
+    public string GetSecretString() => secret;
 }


### PR DESCRIPTION
Adds the option to specify a client secret in the endpoint credential structures read from the ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS environment variable.

A client certificate may be difficult to use in some CICD scenarios, so this adds another option for service principal authentication. Users should still prefer certificates over secrets.