### PR TITLE
Revert UseDefaultRedirectUri

### DIFF
--- a/src/Authentication/AzureArtifacts.cs
+++ b/src/Authentication/AzureArtifacts.cs
@@ -38,11 +38,11 @@ public static class AzureArtifacts
 
     public static PublicClientApplicationBuilder WithBrokerRedirectUri(this PublicClientApplicationBuilder builder)
     {
-        return RuntimeInformation.IsOSPlatform(OSPlatform.OSX) switch
+        return true switch
         {
-            true when RuntimeInformation.IsOSPlatform(OSPlatform.OSX) => builder.WithRedirectUri(MacOSXRedirectUri),
+            _ when RuntimeInformation.IsOSPlatform(OSPlatform.OSX)   => builder.WithRedirectUri(MacOSXRedirectUri),
             _ when RuntimeInformation.IsOSPlatform(OSPlatform.Linux) => builder.WithRedirectUri(LinuxRedirectUri),
-            _ => builder // Windows or other platforms use default
+            _                                                        => builder // Windows or other platforms use default
         };
     }
 


### PR DESCRIPTION
- Revert UseDefaultRedirectUri back to localhost 
- This change broke netfx browser auth because it was returning `https://login.microsoftonline.com/common/oauth2/nativeclient`
which is not configured as a redirect on the client app
- we either need to revert this or consider updating the client app