### PR TITLE
Update installscript.sh to clean content before extractions

### DIFF
--- a/helpers/installcredprovider.sh
+++ b/helpers/installcredprovider.sh
@@ -134,6 +134,12 @@ if [ ! -d "${NUGET_PLUGIN_DIR}" ]; then
   fi
 fi
 
+# Remove existing content from Microsoft credential provider to ensure clean installation
+if [ -d "${NUGET_PLUGIN_DIR}/netcore/CredentialProvider.Microsoft" ]; then
+  echo "INFO: Removing existing Microsoft credential provider for clean installation"
+  rm -rf "${NUGET_PLUGIN_DIR}/netcore/CredentialProvider.Microsoft"
+fi
+
 echo "INFO: Downloading from $URI"
 # Extract netcore from the .tar.gz into the plugin directory
 


### PR DESCRIPTION

This pull request updates the installation script for the Microsoft NuGet credential provider to ensure a clean installation. The main change is the addition of a step that removes any existing credential provider before installing a new one.

Credential provider installation improvements:

* Added logic to `helpers/installcredprovider.sh` to remove any existing `CredentialProvider.Microsoft` directory from `${NUGET_PLUGIN_DIR}/netcore` before proceeding with the installation, ensuring that outdated or conflicting files do not interfere with the new installation.

This was brought to my attention by issue #610