### PR TITLE
Update release helper scripts for new SHA digest

### DIFF
--- a/helpers/installcredproviderrelease.sh
+++ b/helpers/installcredproviderrelease.sh
@@ -13,14 +13,14 @@ set -e
 
 # URL pattern to get latest documented at https://help.github.com/en/articles/linking-to-releases as of 2019-03-29
 INSTALL_SCRIPT="installcredprovider.sh"
+RELEASE_API_URL="https://api.github.com/repos/microsoft/artifacts-credprovider/releases"
 RELEASE_BASE_URL="https://github.com/microsoft/artifacts-credprovider/releases"
-RELEASE_LATEST_DOWNLOAD_URL="https://github.com/microsoft/artifacts-credprovider/releases/latest/download"
 
 # Process version - if not set, use latest
 VERSION=$(echo "${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}" | sed 's/^v//')
 if [ -z "${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}" ] || [ "${AZURE_ARTIFACTS_CREDENTIAL_PROVIDER_VERSION}" = "latest" ]; then
-  DOWNLOAD_URL="${RELEASE_LATEST_DOWNLOAD_URL}"
-  INSTALL_URL="${DOWNLOAD_URL}/${INSTALL_SCRIPT}"
+  API_URL="${RELEASE_API_URL}/latest"
+  INSTALL_URL="${RELEASE_BASE_URL}/latest/download/${INSTALL_SCRIPT}"
   echo "No version specified, using latest release."
 else
   # Validate version format
@@ -31,7 +31,7 @@ else
   
   # For versions 0.x and 1.x, use the last published 1.x version for backward compatibility
   if [[ "${VERSION}" == 0.* ]] || [[ "${VERSION}" == 1.* ]]; then
-    echo "INFO: Using version 1.4.1 for installation script as the minimum supported version"
+    echo "Using installcredprovider script from version 1.4.1 to support 0.x and 1.x versions."
     VERSION="1.4.1"
   fi
 
@@ -39,14 +39,12 @@ else
   TAG_VERSION="v${VERSION}"
   
   echo "Fetching tagged release: ${TAG_VERSION}"
-  DOWNLOAD_URL="${RELEASE_BASE_URL}/download/${TAG_VERSION}"
-  INSTALL_URL="${DOWNLOAD_URL}/${INSTALL_SCRIPT}"
+  API_URL="${RELEASE_API_URL}/tags/${TAG_VERSION}"
+  INSTALL_URL="${RELEASE_BASE_URL}/download/${TAG_VERSION}/${INSTALL_SCRIPT}"
 fi
 
-echo "Fetching versioned release install script at: ${INSTALL_URL}"
-
 # Download and validate the script content
-echo "Fetching install script from ${INSTALL_URL}"
+echo "Fetching versioned release install script from ${INSTALL_URL}"
 
 # Get the script content without writing to disk
 SCRIPT_CONTENT=$(curl -s -S -L "${INSTALL_URL}")
@@ -55,34 +53,50 @@ if [ -z "${SCRIPT_CONTENT}" ]; then
   exit 1
 fi
 
-# Check if we need to validate with checksum
-SHOULD_VALIDATE=true
-if [[ "${VERSION}" == 0.* ]] || [[ "${VERSION}" == 1.* ]]; then
-  SHOULD_VALIDATE=false
-  echo "Skipping checksum validation for version ${VERSION} as it is not available for 0.x and 1.x versions."
-else
-  CHECKSUM_URL="${DOWNLOAD_URL}/artifacts-credprovider-sha256.txt"
-fi
+# Download and validate the checksums from GitHub API
+echo "Fetching release metadata from ${API_URL}"
 
-# Validate the script if checksum is available
-if [ "${SHOULD_VALIDATE}" = true ] && [ ! -z "${CHECKSUM_URL}" ]; then
-  echo "Validating script content with SHA256 checksum"
-  
-  # Download the checksum file content directly into memory
-  echo "Fetching checksum file from ${CHECKSUM_URL}..."
-  CHECKSUM_CONTENT=$(curl -s -S -L "${CHECKSUM_URL}")
-  if [ -z "${CHECKSUM_CONTENT}" ]; then
-    echo "ERROR: Failed to download checksum file"
-    exit 1
+API_RESPONSE=$(curl -s -S -L "${API_URL}")
+if [ -z "${API_RESPONSE}" ]; then
+  echo "ERROR: Failed to download release metadata"
+  exit 1
+else
+  EXPECTED_HASH=""
+  FOUND_ASSET=false
+
+  while IFS= read -r line; do
+    if [[ "${line}" == *"\"name\":"*"\"${INSTALL_SCRIPT}\""* ]]; then
+      FOUND_ASSET=true
+      continue
+    fi
+
+    if [ "${FOUND_ASSET}" = false ]; then
+      continue
+    fi
+
+    if [[ "${line}" == *"\"digest\":"* ]]; then
+      DIGEST_VALUE=$(echo "${line}" | sed 's/.*"digest"[[:space:]]*:[[:space:]]*//' | sed 's/[[:space:]]*,$//' | tr -d '"')
+      break
+    fi
+
+    if [[ "${line}" == *"\"name\":"* ]]; then
+      break
+    fi
+  done <<< "${API_RESPONSE}"
+
+  if [ -n "${DIGEST_VALUE}" ] && [ "${DIGEST_VALUE}" != "null" ]; then
+    if [[ "${DIGEST_VALUE}" == sha256:* ]]; then
+      EXPECTED_HASH="${DIGEST_VALUE#sha256:}"
+    else
+      echo "WARNING: Invalid digest '${DIGEST_VALUE}', expected sha256: format"
+    fi
   fi
-  
-  # Extract expected hash for the install script
-  # Normalize the content to handle different formats
-  NORMALIZED_CHECKSUM_CONTENT=$(echo "${CHECKSUM_CONTENT}" | tr -d '\r')
-  EXPECTED_HASH=$(echo "${NORMALIZED_CHECKSUM_CONTENT}" | grep "${INSTALL_SCRIPT}" | awk '{print $1}')
+
   if [ -z "${EXPECTED_HASH}" ]; then
-    echo "WARNING: Could not find hash for ${INSTALL_SCRIPT} in checksum file, proceeding without validation"
+    echo "WARNING: No digest available for ${INSTALL_SCRIPT} in release metadata, skipping validation"
   else
+    echo "Validating script content with SHA256 checksum"
+
     # Calculate actual hash from the script content
     if command -v shasum >/dev/null 2>&1; then
       ACTUAL_HASH=$(echo "${SCRIPT_CONTENT}" | shasum -a 256 | awk '{print $1}')


### PR DESCRIPTION
Instead of publishing our own sha256 text with each release, utilize the new `digest` field from the GitHub releases API. Example API JSON response: [https://api.github.com/repos/microsoft/artifacts-credprovider/releases/tags/v2.0.0-beta](https://api.github.com/repos/microsoft/artifacts-credprovider/releases/tags/v2.0.0-beta)