### PR TITLE
scripts: check for awk and add sed fallback in installcredproviderrelease.sh

### DIFF
--- a/helpers/installcredproviderrelease.sh
+++ b/helpers/installcredproviderrelease.sh
@@ -105,9 +105,9 @@ else
 
     # Calculate actual hash from the script content
     if command -v shasum >/dev/null 2>&1; then
-      ACTUAL_HASH=$(echo "${SCRIPT_CONTENT}" | shasum -a 256 | awk '{print $1}')
+      ACTUAL_HASH=$(echo "${SCRIPT_CONTENT}" | shasum -a 256 | cut -d ' ' -f 1)
     elif command -v sha256sum >/dev/null 2>&1; then
-      ACTUAL_HASH=$(echo "${SCRIPT_CONTENT}" | sha256sum | awk '{print $1}')
+      ACTUAL_HASH=$(echo "${SCRIPT_CONTENT}" | sha256sum | cut -d ' ' -f 1)
     else
       echo "WARNING: No SHA256 utility available, skipping validation"
       ACTUAL_HASH=""


### PR DESCRIPTION
Resolves: #620 

- Test for awk before using
- Use sed as a fallback
- Fail gracefully when neither is available
- Use cut instead of awk

Tested on both:
- mcr.microsoft.com/dotnet/sdk:8.0-azurelinux3.0
- mcr.microsoft.com/dotnet/sdk:8.0