### PR TITLE
Fix silent WAM broker token acquisition (#664)

### DIFF
--- a/src/Authentication.Tests/TokenProviderTests.cs
+++ b/src/Authentication.Tests/TokenProviderTests.cs
@@ -175,4 +175,59 @@ public class TokenProviderTests
         tokenRequest.ClientId = null;
         Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
     }
+
+    [TestMethod]
+    public async Task MsalTokenProviders_SilentProvider_UsesBrokerApp_WhenProvided()
+    {
+        // Arrange: create two distinct app mocks (Loose so other providers in the iterator don't fail)
+        var nonBrokerApp = new Mock<IPublicClientApplication>();
+        var brokerApp = new Mock<IPublicClientApplication>();
+
+        // broker app should be the one called for silent auth
+        brokerApp.Setup(x => x.GetAccountsAsync())
+            .ReturnsAsync(Array.Empty<IAccount>());
+        brokerApp.Setup(x => x.Authority)
+            .Returns("https://login.microsoftonline.com/common");
+        var brokerAppConfig = new Mock<IAppConfig>();
+        brokerAppConfig.Setup(x => x.IsBrokerEnabled).Returns(false);
+        brokerApp.Setup(x => x.AppConfig).Returns(brokerAppConfig.Object);
+
+        // non-broker app should NOT be called for silent auth
+        nonBrokerApp.Setup(x => x.GetAccountsAsync())
+            .ReturnsAsync(Array.Empty<IAccount>());
+
+        var providers = MsalTokenProviders.Get(nonBrokerApp.Object, loggerMock.Object, appInteractiveBroker: brokerApp.Object).ToList();
+        var silentProvider = providers.First(p => p.Name == "MSAL Silent");
+
+        // Act
+        await silentProvider.GetTokenAsync(new TokenRequest());
+
+        // Assert: broker app was used, not the non-broker app
+        brokerApp.Verify(x => x.GetAccountsAsync(), Times.Once);
+        nonBrokerApp.Verify(x => x.GetAccountsAsync(), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task MsalTokenProviders_SilentProvider_UsesNonBrokerApp_WhenNoBrokerProvided()
+    {
+        // Arrange (Loose so other providers in the iterator don't fail)
+        var nonBrokerApp = new Mock<IPublicClientApplication>();
+
+        nonBrokerApp.Setup(x => x.GetAccountsAsync())
+            .ReturnsAsync(Array.Empty<IAccount>());
+        nonBrokerApp.Setup(x => x.Authority)
+            .Returns("https://login.microsoftonline.com/common");
+        var nonBrokerAppConfig = new Mock<IAppConfig>();
+        nonBrokerAppConfig.Setup(x => x.IsBrokerEnabled).Returns(false);
+        nonBrokerApp.Setup(x => x.AppConfig).Returns(nonBrokerAppConfig.Object);
+
+        var providers = MsalTokenProviders.Get(nonBrokerApp.Object, loggerMock.Object).ToList();
+        var silentProvider = providers.First(p => p.Name == "MSAL Silent");
+
+        // Act
+        await silentProvider.GetTokenAsync(new TokenRequest());
+
+        // Assert: non-broker app was used
+        nonBrokerApp.Verify(x => x.GetAccountsAsync(), Times.Once);
+    }
 }

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -10,7 +10,7 @@
     <!-- IncludeMsalBroker: Set to false to exclude Microsoft.Identity.Client.Broker (removes libmsalruntime.so dependency) -->
     <IncludeMsalBroker Condition="'$(IncludeMsalBroker)' == ''">true</IncludeMsalBroker>
     <DefineConstants Condition="'$(IncludeMsalBroker)' == 'true'">$(DefineConstants);INCLUDE_BROKER</DefineConstants>
-    <VersionPrefix>0.2.7</VersionPrefix>
+    <VersionPrefix>0.2.8</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>

--- a/src/Authentication/MsalTokenProviders.cs
+++ b/src/Authentication/MsalTokenProviders.cs
@@ -15,7 +15,8 @@ public class MsalTokenProviders
         yield return new MsalManagedIdentityTokenProvider(app, logger);
 
         // TODO: Would be more useful if MsalSilentTokenProvider enumerated over each account from the outside
-        yield return new MsalSilentTokenProvider(app, logger);
+        // Use the broker app for silent auth when available so WAM cache can be queried
+        yield return new MsalSilentTokenProvider(appInteractiveBroker ?? app, logger);
 
         if (WindowsIntegratedAuth.IsSupported())
         {


### PR DESCRIPTION
MsalSilentTokenProvider was always receiving the non-broker IPublicClientApplication, so it could never acquire tokens silently from the WAM broker cache. Pass the broker app to the silent provider when available so it can query WAM cached accounts.

- Use appInteractiveBroker ?? app for MsalSilentTokenProvider
- Add regression tests verifying correct app is used
- Bump Microsoft.Artifacts.Authentication version to 0.2.8

#664 