### PR TITLE
Move WIA obsolete warning to after successful token acquisition

### DIFF
--- a/src/Authentication/MsalIntegratedWindowsAuthTokenProvider.cs
+++ b/src/Authentication/MsalIntegratedWindowsAuthTokenProvider.cs
@@ -40,11 +40,15 @@ public class MsalIntegratedWindowsAuthTokenProvider : ITokenProvider
             }
 
             #pragma warning disable CS0618 
-            logger.LogWarning(Resources.MsalWindowsIntegratedAuthObsoleteWarning);
             var result = await app.AcquireTokenByIntegratedWindowsAuth(MsalConstants.AzureDevOpsScopes)
                 .WithUsername(upn)
                 .ExecuteAsync(cancellationToken);
             #pragma warning restore CS0618
+
+            if (result != null)
+            {
+                logger.LogWarning(Resources.MsalWindowsIntegratedAuthObsoleteWarning);
+            }
 
             return result;
         }


### PR DESCRIPTION
The WIA obsolete warning is noisy and should only warn if users are actually successful logging in before we remove it in future version. This change makes sure we only log the MsalWindowsIntegratedAuthObsoleteWarning when WIA actually succeeds and returns a token, rather than before the attempt.