### PR TITLE
[DO NOT MERGE] [Experimental] Fix macOS broker hanging on non-Intune joined devices

### DIFF
--- a/src/Authentication.Tests/TokenProviderTests.cs
+++ b/src/Authentication.Tests/TokenProviderTests.cs
@@ -175,4 +175,139 @@ public class TokenProviderTests
         tokenRequest.ClientId = null;
         Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
     }
+
+    [TestMethod]
+    public async Task MsalBrokerInteractive_ReturnsNull_OnMsalServiceException()
+    {
+        var app = CreateRealApp();
+        // IsUserInteractive() should pass on real PCA, and AcquireTokenInteractive
+        // will throw MsalServiceException during ExecuteAsync.
+        var tokenProvider = new MsalBrokerInteractiveTokenProvider(app, loggerMock.Object);
+        var tokenRequest = new TokenRequest { IsInteractive = true, CanShowDialog = true };
+
+        // On Windows without broker running, we expect the provider to return null
+        // (either from IsUserInteractive check or from exception handling).
+        var result = await tokenProvider.GetTokenAsync(tokenRequest);
+
+        Assert.IsNull(result);
+    }
+
+    [TestMethod]
+    public async Task MsalBrokerInteractive_ReturnsNull_OnMsalClientException()
+    {
+        var app = CreateRealApp();
+        var tokenProvider = new MsalBrokerInteractiveTokenProvider(app, loggerMock.Object);
+        var tokenRequest = new TokenRequest { IsInteractive = true, CanShowDialog = true };
+
+        var result = await tokenProvider.GetTokenAsync(tokenRequest);
+
+        Assert.IsNull(result);
+    }
+
+    /// <summary>
+    /// Verifies that SynchronizationContext is cleared before calling MSAL's
+    /// ExecuteAsync inside RunOnMainThreadAsync. Without this fix, the macOS
+    /// broker's FallbackToNativeMsal would deadlock because MSAL's internal
+    /// system browser fallback posts continuations back to the blocked main
+    /// thread's SynchronizationContext.
+    /// 
+    /// This test simulates the deadlock scenario by:
+    /// 1. Installing a single-threaded SynchronizationContext
+    /// 2. Calling an async method that clears SynchronizationContext before awaiting
+    /// 3. Verifying the continuation completes without deadlocking
+    /// </summary>
+    [TestMethod]
+    [Timeout(10000)] // Deadlock would hang forever; fail fast after 10s
+    public async Task SynchronizationContext_ClearedDuringBrokerCall_PreventsDeadlock()
+    {
+        // Simulate the pattern used in MsalBrokerInteractiveTokenProvider:
+        // save/clear/restore SynchronizationContext around an async call.
+        var completed = false;
+
+        // Use a dedicated thread with a blocking SynchronizationContext to simulate
+        // the macOS main thread scenario. The SingleThreadSynchronizationContext
+        // blocks its thread and pumps posted callbacks, similar to MacMainThreadScheduler.
+        var tcs = new TaskCompletionSource<bool>();
+        var thread = new Thread(() =>
+        {
+            var ctx = new SingleThreadSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(ctx);
+
+            // Post the work to the context, then run the message loop
+            ctx.Post(_ =>
+            {
+                Task.Run(async () =>
+                {
+                    try
+                    {
+                        // This is the pattern from MsalBrokerInteractiveTokenProvider.GetTokenAsync:
+                        var savedContext = SynchronizationContext.Current;
+                        SynchronizationContext.SetSynchronizationContext(null);
+                        try
+                        {
+                            // Simulate MSAL's internal FallbackToNativeMsal -> system browser retry.
+                            // Without clearing SynchronizationContext, this continuation would try
+                            // to post back to the single-threaded context, which is blocked.
+                            await Task.Delay(50).ConfigureAwait(false);
+                            completed = true;
+                        }
+                        finally
+                        {
+                            SynchronizationContext.SetSynchronizationContext(savedContext);
+                        }
+                        tcs.SetResult(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        tcs.SetException(ex);
+                    }
+                    finally
+                    {
+                        ctx.Complete();
+                    }
+                });
+            }, null);
+
+            ctx.RunOnCurrentThread();
+        });
+
+        thread.IsBackground = true;
+        thread.Start();
+
+        await tcs.Task;
+
+        Assert.IsTrue(completed, "Async work should complete without deadlocking");
+    }
+
+    /// <summary>
+    /// A simple single-threaded SynchronizationContext that simulates the macOS
+    /// MacMainThreadScheduler. Callbacks are queued and executed on the owning thread.
+    /// </summary>
+    private sealed class SingleThreadSynchronizationContext : SynchronizationContext
+    {
+        private readonly System.Collections.Concurrent.BlockingCollection<(SendOrPostCallback, object?)> queue = new();
+
+        public override void Post(SendOrPostCallback d, object? state)
+        {
+            queue.Add((d, state));
+        }
+
+        public void Complete() => queue.CompleteAdding();
+
+        public void RunOnCurrentThread()
+        {
+            foreach (var (callback, state) in queue.GetConsumingEnumerable())
+            {
+                callback(state);
+            }
+        }
+    }
+
+    private static IPublicClientApplication CreateRealApp()
+    {
+        return PublicClientApplicationBuilder
+            .Create("d5a56ea4-7369-46b8-a538-c370805301bf")
+            .WithAuthority("https://login.microsoftonline.com/common")
+            .Build();
+    }
 }

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -10,7 +10,7 @@
     <!-- IncludeMsalBroker: Set to false to exclude Microsoft.Identity.Client.Broker (removes libmsalruntime.so dependency) -->
     <IncludeMsalBroker Condition="'$(IncludeMsalBroker)' == ''">true</IncludeMsalBroker>
     <DefineConstants Condition="'$(IncludeMsalBroker)' == 'true'">$(DefineConstants);INCLUDE_BROKER</DefineConstants>
-    <VersionPrefix>0.2.7</VersionPrefix>
+    <VersionPrefix>0.2.8</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>

--- a/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
+++ b/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
@@ -3,6 +3,7 @@
 // Licensed under the MIT license.
 
 using System.Runtime.InteropServices;
+using System.Threading;
 using Microsoft.Extensions.Logging;
 using Microsoft.Identity.Client;
 using Microsoft.Identity.Client.Utils;
@@ -71,10 +72,25 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
             {
                 await scheduler.RunOnMainThreadAsync(async () =>
                 {
-                    result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
-                        .WithPrompt(Prompt.SelectAccount)
-                        .WithUseEmbeddedWebView(false)
-                        .ExecuteAsync(cts.Token);
+                    // Clear the SynchronizationContext so that if the macOS broker fails
+                    // (e.g. FallbackToNativeMsal on non-Intune devices) and MSAL internally
+                    // retries with system browser auth, the async continuations run on the
+                    // thread pool instead of trying to post back to the main thread. Without
+                    // this, the browser fallback's continuations deadlock waiting for the
+                    // main thread which is blocked inside RunOnMainThreadAsync.
+                    var savedContext = SynchronizationContext.Current;
+                    SynchronizationContext.SetSynchronizationContext(null);
+                    try
+                    {
+                        result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
+                            .WithPrompt(Prompt.SelectAccount)
+                            .WithUseEmbeddedWebView(false)
+                            .ExecuteAsync(cts.Token);
+                    }
+                    finally
+                    {
+                        SynchronizationContext.SetSynchronizationContext(savedContext);
+                    }
                 });
             }
             else
@@ -92,6 +108,11 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
         catch (MsalClientException ex) when (ex.ErrorCode == MsalError.AuthenticationCanceledError)
         {
             logger.LogWarning(ex.Message);
+            return null;
+        }
+        catch (MsalException ex)
+        {
+            logger.LogWarning(Resources.MsalBrokerInteractiveFailed, ex.ErrorCode, ex.Message);
             return null;
         }
         catch (OperationCanceledException ex) when (cts.IsCancellationRequested)

--- a/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
+++ b/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
@@ -2,6 +2,7 @@
 //
 // Licensed under the MIT license.
 
+using System.Diagnostics;
 using System.Runtime.InteropServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
@@ -12,7 +13,12 @@ namespace Microsoft.Artifacts.Authentication;
 
 /// <summary>
 /// Interactive token provider that uses the MSAL broker (e.g. WAM on Windows, broker on macOS).
-/// On macOS, broker auth requires the main thread via <see cref="MacMainThreadScheduler"/>.
+/// On macOS, the broker requires the main thread's message loop (via <see cref="MacMainThreadScheduler"/>)
+/// to be running, and an SSO extension (e.g. Company Portal) to be installed.
+///
+/// If no SSO extension is detected, this provider declines to avoid a deadlock in the native
+/// MSAL broker runtime that occurs when FallbackToNativeMsal is triggered on non-Intune devices.
+///
 /// If the scheduler is not running (e.g. ManagedThreadId != 1), this provider declines so the
 /// non-broker <see cref="MsalInteractiveTokenProvider"/> can handle it via system browser instead.
 /// </summary>
@@ -41,13 +47,52 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
         // On macOS, broker auth requires the main thread scheduler to be running.
         // If it's not (e.g. ManagedThreadId != 1 in the dotnet tool shim), decline
         // so the non-broker MsalInteractiveTokenProvider handles it instead.
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX) && !MacMainThreadScheduler.Instance().IsRunning())
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
-            logger.LogTrace(Resources.MacSchedulerNotRunningBrokerSkipped);
-            return false;
+            if (!MacMainThreadScheduler.Instance().IsRunning())
+            {
+                logger.LogTrace(Resources.MacSchedulerNotRunningBrokerSkipped);
+                return false;
+            }
+
+            // On macOS, skip broker auth if no Microsoft SSO extension is installed.
+            // Without an SSO extension, the MSAL native broker runtime deadlocks
+            // inside a synchronous GCD dispatch when FallbackToNativeMsal is triggered.
+            if (!IsMacSsoExtensionAvailable())
+            {
+                logger.LogTrace("No Microsoft SSO extension detected; skipping broker interactive auth to avoid native deadlock.");
+                return false;
+            }
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Checks whether a Microsoft SSO extension is available on macOS by querying pluginkit.
+    /// </summary>
+    private static bool IsMacSsoExtensionAvailable()
+    {
+        try
+        {
+            using var process = new Process();
+            process.StartInfo.FileName = "/usr/bin/pluginkit";
+            process.StartInfo.Arguments = "-m -p com.apple.AppSSO.idp-extension";
+            process.StartInfo.RedirectStandardOutput = true;
+            process.StartInfo.UseShellExecute = false;
+            process.StartInfo.CreateNoWindow = true;
+            process.Start();
+
+            string output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit(5000);
+
+            return output.Contains("com.microsoft.", StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            // If we can't determine SSO extension state, allow broker to try.
+            return true;
+        }
     }
 
     public async Task<AuthenticationResult?> GetTokenAsync(TokenRequest tokenRequest, CancellationToken cancellationToken = default)
@@ -72,31 +117,14 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
             {
                 await scheduler.RunOnMainThreadAsync(async () =>
                 {
-                    // Clear the SynchronizationContext so that if the macOS broker fails
-                    // (e.g. FallbackToNativeMsal on non-Intune devices) and MSAL internally
-                    // retries with system browser auth, the async continuations run on the
-                    // thread pool instead of trying to post back to the main thread. Without
-                    // this, the browser fallback's continuations deadlock waiting for the
-                    // main thread which is blocked inside RunOnMainThreadAsync.
-                    var savedContext = SynchronizationContext.Current;
-                    SynchronizationContext.SetSynchronizationContext(null);
-                    try
-                    {
-                        result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
-                            .WithPrompt(Prompt.SelectAccount)
-                            .WithUseEmbeddedWebView(false)
-                            .ExecuteAsync(cts.Token);
-                    }
-                    finally
-                    {
-                        SynchronizationContext.SetSynchronizationContext(savedContext);
-                    }
+                    result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
+                        .WithPrompt(Prompt.SelectAccount)
+                        .WithUseEmbeddedWebView(false)
+                        .ExecuteAsync(cts.Token);
                 });
             }
             else
             {
-                // Scheduler is not running but CanGetToken allowed us through (non-macOS).
-                // Execute directly — WAM on Windows and broker on Linux don't need the macOS main thread.
                 result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
                     .WithPrompt(Prompt.SelectAccount)
                     .WithUseEmbeddedWebView(false)

--- a/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
+++ b/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
@@ -62,7 +62,7 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
             // inside a synchronous GCD dispatch when FallbackToNativeMsal is triggered.
             if (!s_isMacSsoExtensionAvailable.Value)
             {
-                logger.LogTrace("No Microsoft SSO extension detected; skipping broker interactive auth to avoid native deadlock.");
+                logger.LogTrace(Resources.MacSsoExtensionNotDetected);
                 return false;
             }
         }
@@ -99,6 +99,8 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
         }
     }
 
+    // Guard against native broker deadlocks on macOS (e.g. SSO detection was wrong).
+    // Uses TokenRequest.InteractiveTimeout to prevent the process from hanging forever.
     public async Task<AuthenticationResult?> GetTokenAsync(TokenRequest tokenRequest, CancellationToken cancellationToken = default)
     {
         if (!app.IsUserInteractive())
@@ -119,13 +121,24 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
 
             if (scheduler.IsRunning())
             {
-                await scheduler.RunOnMainThreadAsync(async () =>
+                var brokerTask = scheduler.RunOnMainThreadAsync(async () =>
                 {
                     result = await app.AcquireTokenInteractive(MsalConstants.AzureDevOpsScopes)
                         .WithPrompt(Prompt.SelectAccount)
                         .WithUseEmbeddedWebView(false)
                         .ExecuteAsync(cts.Token);
                 });
+
+                // Guard against native broker deadlocks that ignore cancellation tokens.
+                // If the broker doesn't respond within the timeout, abandon it and return null
+                // so the next provider (system browser) can handle authentication.
+                if (await Task.WhenAny(brokerTask, Task.Delay(tokenRequest.InteractiveTimeout, cts.Token)) != brokerTask)
+                {
+                    logger.LogWarning(Resources.MsalBrokerInteractiveTimedOut, tokenRequest.InteractiveTimeout.TotalSeconds);
+                    return null;
+                }
+
+                await brokerTask;
             }
             else
             {

--- a/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
+++ b/src/Authentication/MsalBrokerInteractiveTokenProvider.cs
@@ -24,6 +24,8 @@ namespace Microsoft.Artifacts.Authentication;
 /// </summary>
 public class MsalBrokerInteractiveTokenProvider : ITokenProvider
 {
+    private static readonly Lazy<bool> s_isMacSsoExtensionAvailable = new Lazy<bool>(DetectMacSsoExtension);
+
     private readonly IPublicClientApplication app;
     private readonly ILogger logger;
 
@@ -58,7 +60,7 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
             // On macOS, skip broker auth if no Microsoft SSO extension is installed.
             // Without an SSO extension, the MSAL native broker runtime deadlocks
             // inside a synchronous GCD dispatch when FallbackToNativeMsal is triggered.
-            if (!IsMacSsoExtensionAvailable())
+            if (!s_isMacSsoExtensionAvailable.Value)
             {
                 logger.LogTrace("No Microsoft SSO extension detected; skipping broker interactive auth to avoid native deadlock.");
                 return false;
@@ -70,8 +72,10 @@ public class MsalBrokerInteractiveTokenProvider : ITokenProvider
 
     /// <summary>
     /// Checks whether a Microsoft SSO extension is available on macOS by querying pluginkit.
+    /// Result is cached for the lifetime of the process via <see cref="s_isMacSsoExtensionAvailable"/>.
+    /// Workaround for https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5940
     /// </summary>
-    private static bool IsMacSsoExtensionAvailable()
+    private static bool DetectMacSsoExtension()
     {
         try
         {

--- a/src/Authentication/Resources.resx
+++ b/src/Authentication/Resources.resx
@@ -165,6 +165,12 @@
   <data name="MacSchedulerNotRunningBrokerSkipped" xml:space="preserve">
     <value>MacMainThreadScheduler is not running and broker is enabled; skipping broker interactive auth as it requires the macOS main thread. Non-broker interactive auth will be used instead.</value>
   </data>
+  <data name="MacSsoExtensionNotDetected" xml:space="preserve">
+    <value>No Microsoft SSO extension detected; skipping broker interactive auth to avoid native deadlock.</value>
+  </data>
+  <data name="MsalBrokerInteractiveTimedOut" xml:space="preserve">
+    <value>Broker interactive auth timed out after {0}s; falling back to non-broker auth.</value>
+  </data>
   <data name="MsalBrokerInteractiveFailed" xml:space="preserve">
     <value>Broker interactive auth failed (ErrorCode: {0}): {1}. Falling back to non-broker interactive auth.</value>
   </data>

--- a/src/Authentication/Resources.resx
+++ b/src/Authentication/Resources.resx
@@ -165,4 +165,7 @@
   <data name="MacSchedulerNotRunningBrokerSkipped" xml:space="preserve">
     <value>MacMainThreadScheduler is not running and broker is enabled; skipping broker interactive auth as it requires the macOS main thread. Non-broker interactive auth will be used instead.</value>
   </data>
+  <data name="MsalBrokerInteractiveFailed" xml:space="preserve">
+    <value>Broker interactive auth failed (ErrorCode: {0}): {1}. Falling back to non-broker interactive auth.</value>
+  </data>
 </root>


### PR DESCRIPTION
Upstream issue: AzureAD/microsoft-authentication-library-for-dotnet#5940

Problem
On macOS devices without a Microsoft SSO extension (e.g. Company Portal), calling `AcquireTokenInteractive` through the broker causes an unrecoverable hang. The native MSAL broker runtime triggers FallbackToNativeMsal when no SSO extension handles the request, which appears to perform a synchronous GCD dispatch (dispatch_sync) back to the main queue - deadlocking because the main thread is already blocked waiting for the broker result. This affects any macOS user who has broker enabled but does not have Company Portal or another Microsoft SSO extension installed.

### Workarounds
All macOs non intune joined users must set `ARTIFACTS_CREDENTIALPROVIDER_MSAL_ALLOW_BROKER=false`

### PR Proposed Fixes

| Approach | Tradeoff |
|---|---|
| **SSO extension detection** — skip broker if `pluginkit` finds no Microsoft SSO extension | Brittle; depends on Apple CLI tool and knowledge of MSAL internals |
| **Timeout guard** — abandon broker via `Task.WhenAny` if it doesn't respond | Main thread stays stuck; adds up to 90s latency before fallback |

### Preferred 
- Native broker / integration fix 
- MSAL exposes a `BrokerOptions` setting to disable native fallback
- MSAL throws `MsalException` instead of deadlocking when no SSO extension is found?