### PR TITLE
[CP -> releases/2.0.2] Prepare 2.0.2 release

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>2.0.1</CredentialProviderVersion>
+    <CredentialProviderVersion>2.0.2</CredentialProviderVersion>
     <VersionSuffix></VersionSuffix>
     <TargetFrameworks>net481;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
Bump CredentialProviderVersion from 2.0.1 to 2.0.2 in `Build.props` to prepare for the 2.0.2 release.

Changes
- Bump CredentialProviderVersion from 2.0.1 to 2.0.2 in `Build.props` to prepare for the 2.0.2 release.


Master PR : #673 