### PR TITLE
Add 3PartySHA2 signing for Newtonsoft.Json.dll and PowerArgs.dll

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -55,5 +55,8 @@
     <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
+    <!-- 3rd-party NuGet dependencies -->
+    <FilesToSign Include="$(OutDir)Newtonsoft.Json.dll" Authenticode="3PartySHA2" />
+    <FilesToSign Include="$(OutDir)PowerArgs.dll" Authenticode="3PartySHA2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
These 3rd-party NuGet dependencies ship without Microsoft Authenticode signatures. Adding FilesToSign entries so MicroBuild signs them with 3PartySHA2 before VSIX packaging.

**Background:** The ESRP Release team has informed us that VS is shipping unsigned and SHA1-only signed files that need to be addressed for compliance. The signing allow list (ExternalWhiteList.csv) will be zeroed out on June 8th.

**The problem:** The VS signing scan flags 2 files in the mscredentialprovider payload:
- Newtonsoft.Json.dll (v13.0.2) - signed by publisher with DigiCert, needs Microsoft 3PartySHA2
- PowerArgs.dll (v3.6.0) - completely unsigned, needs 3PartySHA2

**The fix:** Added FilesToSign entries with 3PartySHA2 cert for both DLLs alongside the existing Microsoft400 entries in CredentialProvider.Microsoft.csproj.

VS tracking bug: https://devdiv.visualstudio.com/DevDiv/_workitems/edit/2991357