### PR TITLE
Upgrade Microsoft.Identity.Client.NativeInterop to 0.20.6

### DIFF
--- a/Build.props
+++ b/Build.props
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CredentialProviderVersion>2.0.2</CredentialProviderVersion>
+    <CredentialProviderVersion>2.0.3</CredentialProviderVersion>
     <VersionSuffix></VersionSuffix>
     <TargetFrameworks>net481;net6.0;net8.0</TargetFrameworks>
   </PropertyGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,6 +11,7 @@
     <PackageVersion Include="Microsoft.Identity.Client" Version="4.77.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.77.1" />
     <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.77.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.NativeInterop" Version="0.20.6" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
     <PackageVersion Include="MSTest" Version="3.8.2" />

--- a/src/Authentication.Tests/TokenProviderTests.cs
+++ b/src/Authentication.Tests/TokenProviderTests.cs
@@ -177,14 +177,8 @@ public class TokenProviderTests
     }
 
     [TestMethod]
-    public async Task MsalTokenProviders_SilentProvider_UsesBrokerApp_WhenProvided_NonWSL()
+    public async Task MsalTokenProviders_SilentProvider_UsesBrokerApp_WhenProvided()
     {
-        if (PlatformInformation.IsWSL())
-        {
-            // On WSL the broker app is intentionally skipped for silent auth; see the WSL test below.
-            Assert.Inconclusive("Skipped on WSL — broker silent auth is disabled there by design.");
-        }
-
         // Arrange: create two distinct app mocks (Loose so other providers in the iterator don't fail)
         var nonBrokerApp = new Mock<IPublicClientApplication>();
         var brokerApp = new Mock<IPublicClientApplication>();
@@ -211,43 +205,6 @@ public class TokenProviderTests
         // Assert: broker app was used, not the non-broker app
         brokerApp.Verify(x => x.GetAccountsAsync(), Times.Once);
         nonBrokerApp.Verify(x => x.GetAccountsAsync(), Times.Never);
-    }
-
-    [TestMethod]
-    public async Task MsalTokenProviders_SilentProvider_UsesNonBrokerApp_OnWSL()
-    {
-        if (!PlatformInformation.IsWSL())
-        {
-            Assert.Inconclusive("Skipped on non-WSL — this test validates WSL-specific broker bypass behavior.");
-        }
-
-        // Arrange: on WSL the silent provider should use the non-broker app even when a broker app is provided,
-        // because the Linux broker daemon does not exist in WSL.
-        // See: https://github.com/microsoft/artifacts-credprovider/issues/TODO
-        var nonBrokerApp = new Mock<IPublicClientApplication>();
-        var brokerApp = new Mock<IPublicClientApplication>();
-
-        nonBrokerApp.Setup(x => x.GetAccountsAsync())
-            .ReturnsAsync(Array.Empty<IAccount>());
-        nonBrokerApp.Setup(x => x.Authority)
-            .Returns("https://login.microsoftonline.com/common");
-        var nonBrokerAppConfig = new Mock<IAppConfig>();
-        nonBrokerAppConfig.Setup(x => x.IsBrokerEnabled).Returns(false);
-        nonBrokerApp.Setup(x => x.AppConfig).Returns(nonBrokerAppConfig.Object);
-
-        // broker app should NOT be called on WSL
-        brokerApp.Setup(x => x.GetAccountsAsync())
-            .ReturnsAsync(Array.Empty<IAccount>());
-
-        var providers = MsalTokenProviders.Get(nonBrokerApp.Object, loggerMock.Object, appInteractiveBroker: brokerApp.Object).ToList();
-        var silentProvider = providers.First(p => p.Name == "MSAL Silent");
-
-        // Act
-        await silentProvider.GetTokenAsync(new TokenRequest());
-
-        // Assert: non-broker app was used on WSL, broker app was not called
-        nonBrokerApp.Verify(x => x.GetAccountsAsync(), Times.Once);
-        brokerApp.Verify(x => x.GetAccountsAsync(), Times.Never);
     }
 
     [TestMethod]

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -10,7 +10,7 @@
     <!-- IncludeMsalBroker: Set to false to exclude Microsoft.Identity.Client.Broker (removes libmsalruntime.so dependency) -->
     <IncludeMsalBroker Condition="'$(IncludeMsalBroker)' == ''">true</IncludeMsalBroker>
     <DefineConstants Condition="'$(IncludeMsalBroker)' == 'true'">$(DefineConstants);INCLUDE_BROKER</DefineConstants>
-    <VersionPrefix>0.2.8</VersionPrefix>
+    <VersionPrefix>0.2.9</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>

--- a/src/Authentication/MsalTokenProviders.cs
+++ b/src/Authentication/MsalTokenProviders.cs
@@ -16,10 +16,8 @@ public class MsalTokenProviders
 
         // TODO: Would be more useful if MsalSilentTokenProvider enumerated over each account from the outside
 
-        // Use the broker app for silent auth on Windows and macOS so the broker cache can be queried.
-        // WSL reports as Linux but has no broker daemon, so fall back to the non-broker app there.
-        // See: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5979
-        yield return new MsalSilentTokenProvider(PlatformInformation.IsWSL() ? app : appInteractiveBroker ?? app, logger);
+        // Use the broker app for silent auth so the broker cache can be queried.
+        yield return new MsalSilentTokenProvider(appInteractiveBroker ?? app, logger);
 
         if (WindowsIntegratedAuth.IsSupported())
         {


### PR DESCRIPTION
- Pin NativeInterop 0.20.6 in Directory.Packages.props (was 0.19.4 transitively)
- Remove WSL broker workaround from MsalTokenProviders (fixed in 0.20.6)
- Bump Authentication library version to 0.2.9
- Bump CredentialProviderVersion to 2.0.3

Fixes/related issues:
https://github.com/microsoft/artifacts-credprovider/issues/663
https://github.com/microsoft/artifacts-credprovider/issues/662
https://github.com/microsoft/artifacts-credprovider/pull/675