### PR TITLE
Fix PowerArgs.dll signing -- move 3rd-party FilesToSign into a target

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -55,8 +55,13 @@
     <FilesToSign Include="$(OutDir)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)$(TargetFileName)" Authenticode="Microsoft400" StrongName="StrongName" />
     <FilesToSign Include="$(IntermediateOutputPath)apphost.exe" Condition=" '$(UseAppHost)' == 'true' " Authenticode="Microsoft400" />
-    <!-- 3rd-party NuGet dependencies -->
-    <FilesToSign Include="$(OutDir)Newtonsoft.Json.dll" Authenticode="3PartySHA2" />
-    <FilesToSign Include="$(OutDir)PowerArgs.dll" Authenticode="3PartySHA2" />
   </ItemGroup>
+
+  <!-- Sign 3rd-party NuGet dependencies after build copies them to OutDir -->
+  <Target Name="Add3rdPartyFilesToSign" BeforeTargets="SignFiles" DependsOnTargets="Build">
+    <ItemGroup>
+      <FilesToSign Include="$(OutDir)Newtonsoft.Json.dll" Authenticode="3PartySHA2" />
+      <FilesToSign Include="$(OutDir)PowerArgs.dll" Authenticode="3PartySHA2" />
+    </ItemGroup>
+  </Target>
 </Project>


### PR DESCRIPTION
Move 3rd-party FilesToSign items into a target to ensure files exist at signing time.

## Problem

PR #678 added static FilesToSign items for PowerArgs.dll and Newtonsoft.Json.dll with 3PartySHA2. When @embetten ran a signed build, Newtonsoft.Json.dll showed a signature but PowerArgs.dll did not.

The root cause: static FilesToSign items are evaluated before NuGet dependencies are copied to \. If the file doesn't exist yet, MicroBuild silently skips it. Newtonsoft.Json.dll appeared signed because it already carries a Microsoft signature from its NuGet package (Microsoft publishes it) -- MicroBuild didn't actually sign it either.

## Fix

Move the 3rd-party FilesToSign items into an Add3rdPartyFilesToSign target with BeforeTargets=SignFiles and DependsOnTargets=Build. This ensures the DLLs are copied to \ before MicroBuild evaluates them for signing.

Bug: [3007364](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/3007364)