### PR TITLE
Fix circular dependency in Add3rdPartyFilesToSign target

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -58,7 +58,7 @@
   </ItemGroup>
 
   <!-- Sign 3rd-party NuGet dependencies after build copies them to OutDir -->
-  <Target Name="Add3rdPartyFilesToSign" BeforeTargets="SignFiles" DependsOnTargets="Build">
+  <Target Name="Add3rdPartyFilesToSign" BeforeTargets="SignFiles">
     <ItemGroup>
       <FilesToSign Include="$(OutDir)Newtonsoft.Json.dll" Authenticode="3PartySHA2" />
       <FilesToSign Include="$(OutDir)PowerArgs.dll" Authenticode="3PartySHA2" />


### PR DESCRIPTION
Remove DependsOnTargets='Build' from Add3rdPartyFilesToSign to break the circular depdency cycle: Build -> SignFiles -> Add3rdPartyFilesToSign -> Build. The target already runs at the correct time via BeforeTargets='SignFiles'.