### PR TITLE
Ensure signed 3P DLLs are included in publish output (#685)

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -64,4 +64,12 @@
       <FilesToSign Include="$(OutDir)PowerArgs.dll" Authenticode="3PartySHA2" />
     </ItemGroup>
   </Target>
+
+  <!-- dotnet publish -no-build resolves 3P DLLs from the NuGet cache (unsigned). 
+      MicroBuild signs them in-place in OutDir during build,
+      so copy the signed OutDir copies over the unsigned publish output. -->
+  <Target Name="CopySignedDepsToPublish" AfterTargets="Publish" Condition="'$(SignType)' != ''">
+    <Copy SourceFiles="$(OutDir)Newtonsoft.Json.dll" DestinationFolder="$(PublishDir)" OverwriteReadOnlyFiles="true" />
+    <Copy SourceFiles="$(OutDir)PowerArgs.dll" DestinationFolder="$(PublishDir)" OverwriteReadOnlyFiles="true" />
+  </Target>
 </Project>


### PR DESCRIPTION
## Problem
`dotnet publish --no-build` resolves 3P NuGet dependencies (Newtonsoft.Json.dll, PowerArgs.dll) from the global NuGet cache rather than from OutDir. MicroBuild signs these DLLs in-place in OutDir during build, but publish never picks up those signed copies — resulting in unsigned 3P binaries in tarballs/zips.

Additionally, `Add3rdPartyFilesToSign` had `DependsOnTargets='Build'` which caused a circular dependency (MSB4006).

## Fix
1. Add `CopySignedDepsToPublish` target (`AfterTargets='Publish'`) that copies the MicroBuild-signed 3P DLLs from OutDir over the unsigned copies in PublishDir. Only runs when `SignType` is set (official builds).
2. Remove `DependsOnTargets='Build'` from `Add3rdPartyFilesToSign` — `BeforeTargets='SignFiles'` alone is sufficient and avoids the circular dependency.

## Verification
- Build succeeds locally (0 errors)
- Confirmed VSIX artifact from pipeline build contains properly Authenticode-signed Newtonsoft.Json.dll and PowerArgs.dll
- Tested locally: tampered OutDir DLL, then published — publish folder received the OutDir copy (not NuGet cache), proving the target works