### PR TITLE
Remove manual VSIX packages.config restore step

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -16,11 +16,6 @@ steps:
 - task: NuGetAuthenticate@1
   displayName: NuGet Authenticate
 
-- ${{ if eq(parameters.sign, 'true') }}:
-  - script: nuget restore packages.config -PackagesDirectory packages
-    displayName: NuGet restore VSIX packages
-    workingDirectory: CredentialProvider.Microsoft.VSIX
-
 - script: dotnet restore CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
   displayName: dotnet restore
 


### PR DESCRIPTION
The MicroBuild 1ES template handles SwixBuild/Sentinel package restore via its swix.feedSource configuration in the internal pipeline. The manual nuget restore step was failing because these packages are not available on the public feed.