### PR TITLE
Add CopyLocalLockFileAssemblies for signing support

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -6,6 +6,7 @@
     <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <ApplicationIcon>helpericons.ico</ApplicationIcon>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <Version>$(CredentialProviderVersion)</Version>
     <PackageVersion>$(CredentialProviderVersion)</PackageVersion>
     <NuspecFile>CredentialProvider.Microsoft.nuspec</NuspecFile>


### PR DESCRIPTION
netcoreapp2.1 Exe projects don't copy NuGet package assemblies to the output directory during build by default (unlike net5+). The MicroBuild signing targets expect Newtonsoft.Json.dll and PowerArgs.dll in OutDir, so this property is needed to make them available for signing.