### PR TITLE
Restore VSIX packages.config restore step

### DIFF
--- a/build/build.yml
+++ b/build/build.yml
@@ -16,6 +16,11 @@ steps:
 - task: NuGetAuthenticate@1
   displayName: NuGet Authenticate
 
+- ${{ if eq(parameters.sign, 'true') }}:
+  - script: nuget restore packages.config -PackagesDirectory packages
+    displayName: NuGet restore VSIX packages
+    workingDirectory: CredentialProvider.Microsoft.VSIX
+
 - script: dotnet restore CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
   displayName: dotnet restore
 


### PR DESCRIPTION
Reverts the removal of the nuget restore step. The swixproj/vsmanproj directly import from the packages directory and need this restore. The MicroBuild template injects the MicroBuildToolset feed into the NuGet auth context during the internal pipeline run.