### PR TITLE
Add VSIX nuget.config for MicroBuildToolset feed (0.1.23.1)

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/nuget.config
+++ b/CredentialProvider.Microsoft.VSIX/nuget.config
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+    <add key="MicroBuildToolset" value="https://pkgs.dev.azure.com/mseng/_packaging/MicroBuildToolset/nuget/v3/index.json" />
+  </packageSources>
+</configuration>


### PR DESCRIPTION
## Root Cause

The VSIX \packages.config\ restore was failing because the packages (\Microsoft.VisualStudioEng.MicroBuild.Core\, \MicroBuild.Core.Sentinel\, \Microsoft.VisualStudioEng.MicroBuild.Plugins.SwixBuild\) only exist on the MicroBuildToolset feed but \
uget restore\ was only looking at the root \
uget.config\ (which points to the public artifacts-credprovider feed).

Master has a dedicated \CredentialProvider.Microsoft.VSIX/nuget.config\ pointing to the MicroBuildToolset feed. This file was missing from the release branches.

## Fix

Add \CredentialProvider.Microsoft.VSIX/nuget.config\ matching master's approach — when \
uget restore\ runs with \workingDirectory: CredentialProvider.Microsoft.VSIX\, it finds this local config and resolves packages from the correct feed.

Companion to #694 (which restored the build step itself).