### PR TITLE
Set TargetFrameworkVersion v4.6.1 in vsmanproj (0.1.23.1)

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
@@ -6,6 +6,7 @@
     <!-- Define properties that drive the manifest creation here. -->
     <FinalizeManifest>true</FinalizeManifest>
     <FinalizeSkipLayout>true</FinalizeSkipLayout>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
The vsmanproj has no explicit \TargetFrameworkVersion\, causing MSBuild to default to v4.0. The VS 18 build agent doesn't have .NET 4.0 reference assemblies, so the build fails with MSB3644.

Set to \4.6.1\ to match the \
et461\ binaries packaged by the VSIX. This project is manifest-only (no compiled code) — the framework version just satisfies MSBuild's \GetReferenceAssemblyPaths\ target.