### PR TITLE
Add SBOM generation for VS insertion (0.1.23.1)

### DIFF
--- a/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
+++ b/CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj
@@ -19,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <MergeManifest Include="$(OutputPath)\*.json" />
+    <MergeManifest Include="$(OutputPath)\*.json" SBOMFileLocation="$(SBOMFilePath)" />
   </ItemGroup>
 
   <Import Project="packages\Microsoft.VisualStudioEng.MicroBuild.Core.1.0.0\build\Microsoft.VisualStudioEng.MicroBuild.Core.targets" />

--- a/build/build.yml
+++ b/build/build.yml
@@ -35,6 +35,11 @@ steps:
   displayName: dotnet publish netcoreapp2.1
 
 - ${{ if eq(parameters.sign, 'true') }}:
+  - task: AzureArtifacts.manifest-generator-task.manifest-generator-task.ManifestGeneratorTask@0
+    displayName: 'Generate SBOM For VS Insertion'
+    inputs:
+      BuildDropPath: '$(Build.SourcesDirectory)\CredentialProvider.Microsoft\bin\$(BuildConfiguration)\net461'
+
   - task: MSBuild@1
     displayName: Build swixproj
     inputs:
@@ -47,7 +52,7 @@ steps:
     inputs:
       solution: 'CredentialProvider.Microsoft.VSIX/Microsoft.CredentialProvider.vsmanproj'
       configuration: '$(BuildConfiguration)'
-      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\'
+      msbuildArguments: '/p:OutputPath=$(Build.ArtifactStagingDirectory)\$(BuildConfiguration)\vsix\ /p:SBOMFilePath=$(Build.SourcesDirectory)\CredentialProvider.Microsoft\bin\$(BuildConfiguration)\net461\_manifest\spdx_2.2\manifest.spdx.json'
 
 - ${{ if ne(parameters.sign, 'true') }}:
   - script: dotnet test CredentialProvider.Microsoft.Tests/CredentialProvider.Microsoft.Tests.csproj --logger trx --results-directory $(Agent.TempDirectory)


### PR DESCRIPTION
Adds SBOM generation for VS component insertion compliance.

Changes:
- Add ManifestGeneratorTask to generate SBOM manifest targeting net461 output
- Pass SBOMFilePath to vsmanproj so the SwixBuild plugin includes the SBOM payload in the .vsman

This ensures the .vsman file has an SBOM payload entry as required by the VS insertion SBOM check PR policy.