### PR TITLE
Bump Microsoft.Identity.Client packages from 4.77.1 to 4.85.1

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
     <PackageVersion Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.Identity.Client" Version="4.77.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.77.1" />
-    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.77.1" />
+    <PackageVersion Include="Microsoft.Identity.Client" Version="4.85.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Broker" Version="4.85.1" />
+    <PackageVersion Include="Microsoft.Identity.Client.Extensions.Msal" Version="4.85.1" />
     <PackageVersion Include="Microsoft.Identity.Client.NativeInterop" Version="0.20.6" />
     <PackageVersion Include="Microsoft.VisualStudioEng.MicroBuild.Core" Version="1.0.0" />
     <PackageVersion Include="Moq" Version="4.18.4" />
@@ -18,7 +18,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageVersion Include="NuGet.Protocol" Version="6.7.1" />
     <PackageVersion Include="PowerArgs" Version="3.6.0" />
-    <PackageVersion Include="System.Formats.Asn1" Version="6.0.1" />
+    <PackageVersion Include="System.Formats.Asn1" Version="8.0.1" />
     <PackageVersion Include="System.Text.Json" Version="6.0.10" />
     <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
   </ItemGroup>

--- a/src/Authentication/Microsoft.Artifacts.Authentication.csproj
+++ b/src/Authentication/Microsoft.Artifacts.Authentication.csproj
@@ -10,7 +10,7 @@
     <!-- IncludeMsalBroker: Set to false to exclude Microsoft.Identity.Client.Broker (removes libmsalruntime.so dependency) -->
     <IncludeMsalBroker Condition="'$(IncludeMsalBroker)' == ''">true</IncludeMsalBroker>
     <DefineConstants Condition="'$(IncludeMsalBroker)' == 'true'">$(DefineConstants);INCLUDE_BROKER</DefineConstants>
-    <VersionPrefix>0.2.9</VersionPrefix>
+    <VersionPrefix>0.2.10</VersionPrefix>
     <Authors>Microsoft</Authors>
     <Owners>Microsoft</Owners>
     <Description>Azure Artifacts authentication library for credential providers.</Description>


### PR DESCRIPTION
Bumps MSAL packages to latest:
- Microsoft.Identity.Client 4.77.1 → 4.85.1
- Microsoft.Identity.Client.Broker 4.77.1 → 4.85.1
- Microsoft.Identity.Client.Extensions.Msal 4.77.1 → 4.85.1
- System.Formats.Asn1 6.0.1 → 8.0.1 (required by MSAL 4.85.1)

Microsoft.Identity.Client.NativeInterop stays at 0.20.6 (already latest).