### PR TITLE
Add prebuilt dotnet tool shim RIDs for mac and windows

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
     <NuspecFile>Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec</NuspecFile>
+    <!-- Prebuilt tool shims are included only for macOS and Windows because those launchers must be signed and notarized; Linux does not require an equivalent shim-signing step. -->
     <PackAsToolShimRuntimeIdentifiers>osx-arm64;osx-x64;win-arm64;win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackAsTool)' == 'true'">

--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
     <NuspecFile>Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec</NuspecFile>
+    <PackAsToolShimRuntimeIdentifiers>osx-arm64;osx-x64;win-arm64;win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackAsTool)' == 'true'">
       <None Update="DotNetToolSettings.xml">


### PR DESCRIPTION
## Summary
- Add prebuilt dotnet tool shim runtime identifiers for macOS and Windows.
- Include the win-x86 shim RID for broker-auth packaging and signing flow alignment.

## Validation
- Local restore, publish, and pack completed successfully.
- Verified packaged shims under tools/net8.0/any/shims: osx-arm64, osx-x64, win-arm64, win-x64, and win-x86.

## Related
- Cherry-pick PR into releases/2.0.4 will follow.