### PR TITLE
[2.0.4] Cherry-pick: add prebuilt dotnet tool shim RIDs

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -19,6 +19,7 @@
   <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
     <NuspecFile>Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec</NuspecFile>
+    <PackAsToolShimRuntimeIdentifiers>osx-arm64;osx-x64;win-arm64;win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackAsTool)' == 'true'">
       <None Update="DotNetToolSettings.xml">


### PR DESCRIPTION
Cherry-pick of 8ac35c46c55ac164938b9bd29b47eafb03a34321 from users/embetten/broker-shim-signing-fix-master.

## Summary
- Add prebuilt dotnet tool shim runtime identifiers for macOS and Windows.
- Include the win-x86 RID.

## Validation
- Local restore, publish, and pack validated successfully.
- Verified shim entries in the produced nupkg.