### PR TITLE
Add Workload Identity Federation as a credential type on feed endpoints

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskMsalTokenProvidersFactory.cs
@@ -41,6 +41,7 @@ internal class VstsBuildTaskMsalTokenProvidersFactory : ITokenProvidersFactory
 
     private IEnumerable<ITokenProvider> ConstructTokenProvidersList(IPublicClientApplication app)
     {
+        yield return new MsalFederatedIdentityTokenProvider(app, logger);
         yield return new MsalServicePrincipalTokenProvider(app, logger);
         yield return new MsalManagedIdentityTokenProvider(app, logger);
     }

--- a/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
+++ b/CredentialProvider.Microsoft/CredentialProviders/VstsBuildTaskServiceEndpoint/VstsBuildTaskServiceEndpointCredentialProvider.cs
@@ -101,7 +101,10 @@ namespace NuGetCredentialProvider.CredentialProviders.VstsBuildTaskServiceEndpoi
                     InteractiveTimeout = TimeSpan.FromSeconds(EnvUtil.GetDeviceFlowTimeoutFromEnvironmentInSeconds(Logger)),
                     ClientId = matchingEndpoint.ClientId,
                     ClientCertificate = clientCertificate,
-                    TenantId = authInfo.EntraTenantId
+                    ClientAssertionFilePath = matchingEndpoint.ClientAssertionFilePath,
+                    TenantId = !string.IsNullOrWhiteSpace(matchingEndpoint.TenantId)
+                        ? matchingEndpoint.TenantId
+                        : authInfo.EntraTenantId
                 };
 
                 foreach (var tokenProvider in tokenProviders)

--- a/CredentialProvider.Microsoft/Util/FeedEndpointCredentialsParser.cs
+++ b/CredentialProvider.Microsoft/Util/FeedEndpointCredentialsParser.cs
@@ -29,10 +29,14 @@ public class EndpointCredentials
     public string Endpoint { get; set; }
     [JsonPropertyName("clientId")]
     public string ClientId { get; set; }
+    [JsonPropertyName("tenantId")]
+    public string TenantId { get; set; }
     [JsonPropertyName("clientCertificateFilePath")]
     public string CertificateFilePath { get; set; }
     [JsonPropertyName("clientCertificateSubjectName")]
     public string CertificateSubjectName { get; set; }
+    [JsonPropertyName("clientAssertionFilePath")]
+    public string ClientAssertionFilePath { get; set; }
 }
 
 public class EndpointCredentialsContainer

--- a/README.md
+++ b/README.md
@@ -267,12 +267,14 @@ The Credential Provider accepts a set of environment variables. Not all of them 
     ```
 -   `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS` (Preferred): JSON that contains an array of endpoints, usernames and azure service principal information needed to authenticate to Azure Artifacts feed endpoints. Example:
     ```javascript
-    {"endpointCredentials": [{"endpoint":"http://example.index.json", "clientId":"required", "clientCertificateSubjectName":"optional", "clientCertificateFilePath":"optional"}]}
+    {"endpointCredentials": [{"endpoint":"http://example.index.json", "clientId":"required", "tenantId":"optional", "clientCertificateSubjectName":"optional", "clientCertificateFilePath":"optional", "clientAssertionFilePath":"optional"}]}
     ```
     - `endpoint`: Required. Feed URL to authenticate.
-    - `clientId`: Required for both Azure Managed Identities and Service Principals. For user assigned managed identities enter the Entra client id. For system assigned managed identities set the value to `system`.
+    - `clientId`: Required for Managed Identities, Service Principals, and Workload Identity Federation. For user-assigned managed identities enter the Entra client id. For system-assigned managed identities set the value to `system`. For Service Principals and Workload Identity Federation enter the App Registration's application (client) id.
+    - `tenantId`: Optional. The Entra tenant id that hosts the App Registration. Only used for Service Principal and Workload Identity Federation authentication; if omitted, the tenant is discovered from the feed's authority.
     - `clientCertificateSubjectName`: Subject Name of the certificate located in the CurrentUser or LocalMachine certificate store. Optional field. Only used for service principal authentication.
-    - `clientCertificateFilePath`: File path location of the certificate on the machine. Optional field. Only used for service principal authentication. 
+    - `clientCertificateFilePath`: File path location of the certificate on the machine. Optional field. Only used for service principal authentication.
+    - `clientAssertionFilePath`: File path to a file containing a signed JWT client assertion (Workload Identity Federation). Optional field. When set together with `clientId`, enables federated-identity authentication via MSAL's confidential-client flow. The file is re-read on every token acquisition, so external refreshers (kubelet, scheduled tasks, Azure Pipelines OIDC re-signing, etc.) take effect without restarting the caller. See [Azure Workload Identity Federation](https://learn.microsoft.com/entra/workload-id/workload-identity-federation). Because federated identity authenticates as a service principal, users should combine this with `ARTIFACTS_CREDENTIALPROVIDER_RETURN_ENTRA_TOKENS=true` so the Entra bearer is returned directly (service principals cannot mint Azure DevOps session tokens).
 
 ## Release version 1.0.0
 

--- a/src/Authentication.Tests/TokenProviderTests.cs
+++ b/src/Authentication.Tests/TokenProviderTests.cs
@@ -177,6 +177,56 @@ public class TokenProviderTests
     }
 
     [TestMethod]
+    public void MsalFederatedIdentityContractTest()
+    {
+        appMock.Setup(x => x.AppConfig)
+            .Returns(new Mock<IAppConfig>().Object);
+
+        var tokenProvider = new MsalFederatedIdentityTokenProvider(appMock.Object, loggerMock.Object);
+        var tokenRequest = new TokenRequest();
+
+        Assert.IsNotNull(tokenProvider.Name);
+        Assert.IsFalse(tokenProvider.IsInteractive);
+
+        // no inputs at all -> cannot get token
+        Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
+
+        // create a real, existing assertion file to satisfy File.Exists()
+        var assertionFile = Path.Combine(Path.GetTempPath(), $"cp-fed-{Guid.NewGuid():N}.jwt");
+        File.WriteAllText(assertionFile, "fake.jwt.assertion");
+        try
+        {
+            // all three set + file exists -> true
+            tokenRequest.ClientId = "clientId";
+            tokenRequest.TenantId = "tenantId";
+            tokenRequest.ClientAssertionFilePath = assertionFile;
+            Assert.IsTrue(tokenProvider.CanGetToken(tokenRequest));
+
+            // missing ClientId -> false
+            tokenRequest.ClientId = null;
+            Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
+            tokenRequest.ClientId = "clientId";
+
+            // missing TenantId -> false
+            tokenRequest.TenantId = null;
+            Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
+            tokenRequest.TenantId = "tenantId";
+
+            // missing ClientAssertionFilePath -> false
+            tokenRequest.ClientAssertionFilePath = null;
+            Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
+
+            // path set but file does not exist -> false
+            tokenRequest.ClientAssertionFilePath = Path.Combine(Path.GetTempPath(), $"cp-fed-missing-{Guid.NewGuid():N}.jwt");
+            Assert.IsFalse(tokenProvider.CanGetToken(tokenRequest));
+        }
+        finally
+        {
+            if (File.Exists(assertionFile)) File.Delete(assertionFile);
+        }
+    }
+
+    [TestMethod]
     public async Task MsalTokenProviders_SilentProvider_UsesBrokerApp_WhenProvided()
     {
         // Arrange: create two distinct app mocks (Loose so other providers in the iterator don't fail)

--- a/src/Authentication/MsalFederatedIdentityTokenProvider.cs
+++ b/src/Authentication/MsalFederatedIdentityTokenProvider.cs
@@ -1,0 +1,68 @@
+// Copyright (c) Microsoft. All rights reserved.
+//
+// Licensed under the MIT license.
+
+using Microsoft.Extensions.Logging;
+using Microsoft.Identity.Client;
+
+namespace Microsoft.Artifacts.Authentication
+{
+    public class MsalFederatedIdentityTokenProvider : ITokenProvider
+    {
+        public string Name => "MSAL Federated Identity";
+        public bool IsInteractive => false;
+
+        private readonly ILogger logger;
+        private readonly IAppConfig appConfig;
+
+        public MsalFederatedIdentityTokenProvider(IPublicClientApplication app, ILogger logger)
+        {
+            this.appConfig = app.AppConfig;
+            this.logger = logger;
+        }
+
+        public bool CanGetToken(TokenRequest tokenRequest)
+        {
+            if (string.IsNullOrWhiteSpace(tokenRequest.ClientId)) return false;
+            if (string.IsNullOrWhiteSpace(tokenRequest.TenantId)) return false;
+            if (string.IsNullOrWhiteSpace(tokenRequest.ClientAssertionFilePath)) return false;
+            if (!File.Exists(tokenRequest.ClientAssertionFilePath)) return false;
+            return true;
+        }
+
+        public async Task<AuthenticationResult?> GetTokenAsync(TokenRequest tokenRequest, CancellationToken cancellationToken = default)
+        {
+            try
+            {
+                if (!CanGetToken(tokenRequest))
+                {
+                    logger.LogTrace("InvalidInputs");
+                    return null;
+                }
+
+                var assertionPath = tokenRequest.ClientAssertionFilePath!;
+
+                var app = ConfidentialClientApplicationBuilder.Create(tokenRequest.ClientId)
+                    .WithHttpClientFactory(appConfig.HttpClientFactory)
+                    .WithLogging(appConfig.LoggingCallback, appConfig.LogLevel, appConfig.EnablePiiLogging, appConfig.IsDefaultPlatformLoggingEnabled)
+                    .WithTenantId(tokenRequest.TenantId)
+                    .WithClientAssertion((AssertionRequestOptions _) =>
+                    {
+                        return Task.FromResult(File.ReadAllText(assertionPath).Trim());
+                    })
+                    .Build();
+
+                var result = await app.AcquireTokenForClient(MsalConstants.AzureDevOpsScopes)
+                    .ExecuteAsync(cancellationToken)
+                    .ConfigureAwait(false);
+
+                return result;
+            }
+            catch (Exception ex)
+            {
+                logger.LogTrace(ex.Message);
+                return null;
+            }
+        }
+    }
+}

--- a/src/Authentication/TokenRequest.cs
+++ b/src/Authentication/TokenRequest.cs
@@ -40,4 +40,12 @@ public class TokenRequest
     public string? TenantId { get; set; } = null;
 
     public X509Certificate2? ClientCertificate { get; set; } = null;
+
+    /// <summary>
+    /// Path to a file containing a signed JWT client assertion (federated
+    /// workload identity). When set together with ClientId + TenantId,
+    /// enables MsalFederatedIdentityTokenProvider to exchange the assertion
+    /// for an ADO-audience access token via the confidential-client flow.
+    /// </summary>
+    public string? ClientAssertionFilePath { get; set; } = null;
 }


### PR DESCRIPTION
## Summary

Adds Workload Identity Federation as a third credential type on the existing `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS` per-feed JSON configuration, alongside the certificate-based Service Principal and Managed Identity flows already supported. Users add a `clientAssertionFilePath` to a feed entry; a new `MsalFederatedIdentityTokenProvider` exchanges the signed JWT client assertion for an Entra access token via MSAL''s confidential-client `WithClientAssertion` flow.

## Motivation

Today there is no supported path for using the credential provider with a federated-credential-configured App Registration. The nearest existing provider, `MsalServicePrincipalTokenProvider`, requires an X.509 client certificate on `TokenRequest.ClientCertificate` and has no field for a client assertion string. Callers who authenticate via WIF (GitHub Actions OIDC, Azure DevOps federated service connections, AKS workload identity pods, Azure VMs where a user-assigned managed identity signs assertions for an App Registration, etc.) currently have to fall back to:

- Manually calling `az account get-access-token` and stuffing the result into `NuGet.Config` as a bearer -- brittle, expires in ~1 hour, and misses the credprovider''s caching / renewal.
- Long-lived Personal Access Tokens -- the exact anti-pattern WIF is meant to eliminate.

## Design

Follows the existing architecture exactly: WIF is another credential type on the same JSON blob that already carries SP-cert and MI configuration, wired through the same `VstsBuildTaskServiceEndpointCredentialProvider` and `VstsBuildTaskMsalTokenProvidersFactory`. Symmetric with `clientCertificateFilePath`.

**JSON schema addition (all fields optional):**

```json
{
  "endpointCredentials": [{
    "endpoint": "https://pkgs.dev.azure.com/.../nuget/v3/index.json",
    "clientId": "<App Registration client id>",
    "tenantId": "<tenant hosting the App Reg>",
    "clientAssertionFilePath": "/var/run/secrets/azure/tokens/azure-identity-token"
  }]
}
```

## What this PR does NOT change

- Existing providers (Silent, WIA, Broker, Interactive, DeviceCode, Service Principal, Managed Identity, Build Task, external endpoints) are untouched.
- `VstsCredentialProvider` (interactive flow) is untouched.
- Pre-existing behavior: absent `clientAssertionFilePath`, the SP-cert / MI providers run exactly as before.
- The pre-existing `ARTIFACTS_CREDENTIALPROVIDER_RETURN_ENTRA_TOKENS` env var is not modified -- only its use is documented as the recommended companion setting.

## Changes

| File | Change |
|---|---|
| `src/Authentication/TokenRequest.cs` | Add nullable `ClientAssertionFilePath` property |
| `src/Authentication/MsalFederatedIdentityTokenProvider.cs` | **New** -- confidential-client MSAL provider that reads the assertion file on every call |
| `CredentialProvider.Microsoft/Util/FeedEndpointCredentialsParser.cs` | Add `tenantId` and `clientAssertionFilePath` optional fields on `EndpointCredentials` |
| `.../VstsBuildTaskServiceEndpointCredentialProvider.cs` | Populate `TokenRequest.ClientAssertionFilePath` from JSON; prefer JSON `tenantId` over discovered authority tenant |
| `.../VstsBuildTaskMsalTokenProvidersFactory.cs` | Yield `MsalFederatedIdentityTokenProvider` before SP / MI |
| `README.md` | Extend the `ARTIFACTS_CREDENTIALPROVIDER_FEED_ENDPOINTS` schema doc with the new fields |
| `src/Authentication.Tests/TokenProviderTests.cs` | New `MsalFederatedIdentityContractTest` mirroring `MsalServicePrincipalContractTest` |

**141 insertions, 4 deletions across 7 files.**

## Behavior

- `MsalFederatedIdentityTokenProvider.CanGetToken()` returns true only when all of `ClientId`, `TenantId`, `ClientAssertionFilePath` are set on the `TokenRequest` AND the assertion file exists on disk.
- The assertion file is re-read on **every** token acquisition (via `WithClientAssertion(Func<string>)`), so external refreshers (kubelet, scheduled tasks, Azure Pipelines OIDC re-signing) take effect without restarting the caller.
- Ordering: federated -> SP-cert -> MI. First provider whose `CanGetToken` returns true wins.

## Companion setting

Because WIF authenticates as a service principal -- and SPNs cannot mint Azure DevOps `VssSessionToken`s (ADO returns 403 on `POST /_apis/Token/SessionTokens`) -- users on the WIF path should also set the existing `ARTIFACTS_CREDENTIALPROVIDER_RETURN_ENTRA_TOKENS=true` opt-in so the provider returns the Entra bearer directly as basic-auth password. That env var pre-exists this PR; the README extension documents the pairing.

## Testing

- Added `MsalFederatedIdentityContractTest` covering the `CanGetToken` matrix: all set + file exists -> true; any of ClientId/TenantId/ClientAssertionFilePath missing -> false; path set but file missing -> false.
- Full auth test suite: **17 passed, 0 failed** on net8.0 (7 skipped are network-gated integration tests unrelated to this change).
- Manually validated end-to-end on an Azure VM: a user-assigned managed identity signs JWT assertions for an App Registration that is a Feed Reader on an Azure DevOps Artifacts feed. `dotnet restore` and `nuget install` both succeed with no PAT and no interactive prompt.

## Related links

- Azure SDK''s [`WorkloadIdentityCredential`](https://learn.microsoft.com/dotnet/api/azure.identity.workloadidentitycredential)
- [Azure Workload Identity Federation overview](https://learn.microsoft.com/entra/workload-id/workload-identity-federation)

## Follow-ups (not in this PR)

- Could add a small env-var -> JSON adapter that recognizes the standard Azure SDK `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_FEDERATED_TOKEN_FILE` contract and synthesizes an `EndpointCredentials` entry -- happy to do that in a follow-up if maintainers want it.

Happy to iterate on naming, ordering, or split into smaller commits if that helps review.
