### PR TITLE
Fix dotnet tool shim for macOS broker authentication

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -18,8 +18,10 @@
   
   <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <PackageId>Microsoft.Artifacts.CredentialProvider.NuGet.Tool</PackageId>
     <NuspecFile>Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec</NuspecFile>
     <PackAsToolShimRuntimeIdentifiers>osx-arm64;osx-x64;win-arm64;win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <ToolCommandName>nuget-plugin-microsoft-artifacts-credential-provider</ToolCommandName>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackAsTool)' == 'true'">
       <None Update="DotNetToolSettings.xml">

--- a/CredentialProvider.Microsoft/Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec
+++ b/CredentialProvider.Microsoft/Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec
@@ -23,6 +23,7 @@
        <file src="..\README.md" target="\" />
        <file src="ThirdPartyNotices.txt" target="\" />
        <file src="EULA_Microsoft Visual Studio Team Services Credential Provider.docx" target="\" />
-       <file src="bin\$Configuration$\net8.0\publish\**\*.*" target="tools\net8.0\any" />
+       <file src="bin\$Configuration$\net8.0\publish\**\*.*" exclude="bin\$Configuration$\net8.0\publish\shims\**\*.*" target="tools\net8.0\any" />
+       <file src="bin\$Configuration$\net8.0\publish\shims\**\*" target="tools\net8.0\any\shims" />
     </files>
 </package>


### PR DESCRIPTION
Add PackageId and ToolCommandName to csproj (under PackAsTool condition) so that dotnet publish generates shims with:
- The correct command name (nuget-plugin-microsoft-artifacts-credential-provider) so dotnet tool install uses the pre-built signed shim instead of generating its own ad-hoc signed one
- The correct embedded DLL path matching the tool store layout

Update nuspec to include extensionless macOS shims that are not matched by the existing **\*.* glob pattern.