### PR TITLE
Forward-port 2.0.4 macOS tool shim fix to master

### DIFF
--- a/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
+++ b/CredentialProvider.Microsoft/CredentialProvider.Microsoft.csproj
@@ -18,9 +18,11 @@
   
   <PropertyGroup Condition="'$(PackAsTool)' == 'true'">
     <TargetFrameworks>net8.0</TargetFrameworks>
+    <PackageId>Microsoft.Artifacts.CredentialProvider.NuGet.Tool</PackageId>
     <NuspecFile>Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec</NuspecFile>
     <!-- Prebuilt tool shims are included only for macOS and Windows because those launchers must be signed and notarized; Linux does not require an equivalent shim-signing step. -->
     <PackAsToolShimRuntimeIdentifiers>osx-arm64;osx-x64;win-arm64;win-x64;win-x86</PackAsToolShimRuntimeIdentifiers>
+    <ToolCommandName>nuget-plugin-microsoft-artifacts-credential-provider</ToolCommandName>
   </PropertyGroup>
   <ItemGroup Condition="'$(PackAsTool)' == 'true'">
       <None Update="DotNetToolSettings.xml">

--- a/CredentialProvider.Microsoft/Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec
+++ b/CredentialProvider.Microsoft/Microsoft.Artifacts.CredentialProvider.NuGet.Tool.nuspec
@@ -23,6 +23,7 @@
        <file src="..\README.md" target="\" />
        <file src="ThirdPartyNotices.txt" target="\" />
        <file src="EULA_Microsoft Visual Studio Team Services Credential Provider.docx" target="\" />
-       <file src="bin\$Configuration$\net8.0\publish\**\*.*" target="tools\net8.0\any" />
+       <file src="bin\$Configuration$\net8.0\publish\**\*.*" exclude="bin\$Configuration$\net8.0\publish\shims\**\*.*" target="tools\net8.0\any" />
+       <file src="bin\$Configuration$\net8.0\publish\shims\**\*" target="tools\net8.0\any\shims" />
     </files>
 </package>


### PR DESCRIPTION
## Summary

- Forward-port the .NET tool shim fix released in `2.0.4` through #708.
- Configure the package identity and command name used to generate the signed shims.
- Package extensionless macOS shims while preserving master's explanation of the supported shim RIDs.

The prebuilt shim RID change from release PR #706 is already present on `master` through #705, so this PR includes only the remaining release fix.

## Validation

- `dotnet build .\CredentialProvider.Microsoft\CredentialProvider.Microsoft.csproj --configuration Release --no-restore`
- Attempted the `PackAsTool` pack path; the local SDK reached `GenerateShims` but could not complete because the macOS apphost runtime pack is unavailable in the local environment.